### PR TITLE
Fix sticky table borders in Trilium 0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
+
 ## 1.0.0 - 2021-04-17
 
 - Initial release.

--- a/src/view/TableView.scss
+++ b/src/view/TableView.scss
@@ -21,9 +21,6 @@
 	left: 0;
 }
 
-// box-shadow fakes the border for the first row and column since position:
-// sticky doesn't move borders.
-
 .table.collection-view-table thead th {
 	position: sticky;
 	top: 0;

--- a/src/view/TableView.scss
+++ b/src/view/TableView.scss
@@ -2,12 +2,16 @@
 // .table is needed to override Bootstrap.
 
 .table.collection-view-table {
+	border: 0;
+	border-collapse: separate;
+	border-spacing: 0;
 	margin: 0;
 }
 
 .table.collection-view-table thead th,
 .table.collection-view-table tbody td {
-	border: 1px solid var(--collection-view-table-border-color);
+	border-color: var(--collection-view-table-border-color);
+	border-width: 0 1px 1px 0;
 	padding: 0.4em;
 	white-space: nowrap;
 }
@@ -20,25 +24,22 @@
 // box-shadow fakes the border for the first row and column since position:
 // sticky doesn't move borders.
 
-.collection-view-table thead th {
+.table.collection-view-table thead th {
 	position: sticky;
 	top: 0;
 	background: var(--accented-background-color);
-	box-shadow: 0 1px var(--collection-view-table-border-color),
-		0 -1px var(--collection-view-table-border-color);
+	border-width: 1px 1px 1px 0;
 	z-index: 2;
 }
 
 .collection-view-table thead th:first-child {
 	z-index: 3;
-	box-shadow: 1px 0 var(--collection-view-table-border-color),
-		0 1px var(--collection-view-table-border-color);
+	border-width: 1px;
 }
 
 .collection-view-table tbody td:first-child {
 	background: var(--main-background-color);
-	box-shadow: 1px 0 var(--collection-view-table-border-color),
-		-1px 0 var(--collection-view-table-border-color);
+	border-width: 0 1px 1px 1px;
 	min-width: 300px;
 	white-space: normal;
 }


### PR DESCRIPTION
Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.