### PR TITLE
Fix multiple values in table cells not separated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for the "include note" feature, allowing views to be embedded in other notes.
 - Add `wrap` attribute setting for table views for enabling text wrapping.
 - Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
+- Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.
 
 ## 1.0.0 - 2021-04-17
 

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -81,4 +81,14 @@ export class AttributeConfig {
 	affix(text: string): string {
 		return `${this.prefix}${text}${this.suffix}`;
 	}
+
+	/**
+	 * Returns the separator to use for multiple attribute values in a table.
+	 */
+	makeSeparator(): HTMLElement | Text {
+		if (this.badge) {
+			return document.createTextNode(" ");
+		}
+		return document.createElement("br");
+	}
 }

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -149,21 +149,14 @@ export class TableView extends View {
 		attributeConfig: AttributeConfig
 	): Promise<Array<HTMLElement | Text>> {
 		const $values = await this.renderAttributeValues(note, attributeConfig);
-
-		let $separator: HTMLElement | Text | undefined;
-		if (attributeConfig.badge) {
-			$separator = document.createTextNode(" ");
-		} else if (!attributeConfig.denominatorName) {
-			$separator = document.createElement("br");
-		}
-		if (!$separator) {
+		if (attributeConfig.denominatorName) {
 			return $values;
 		}
 
 		const $separatedValues: Array<HTMLElement | Text> = [];
 		$values.forEach(($value, i) => {
-			if ($separator && i) {
-				$separatedValues.push($separator);
+			if (i) {
+				$separatedValues.push(attributeConfig.makeSeparator());
 			}
 			$separatedValues.push($value);
 		});


### PR DESCRIPTION
Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.