### PR TITLE
`boolean` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `wrap` attribute setting for table views for enabling text wrapping.
 - Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
 - Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.
+- Fix `boolean` checkboxes being inverted (true as unchecked, false as checked).
 
 ## 1.0.0 - 2021-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
 - Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.
 - Fix `boolean` checkboxes being inverted (true as unchecked, false as checked).
+- Fix `prefix` and `suffix` settings not working with `boolean` checkboxes.
 
 ## 1.0.0 - 2021-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for the "include note" feature, allowing views to be embedded in other notes.
 - Add `wrap` attribute setting for table views for enabling text wrapping.
+- `boolean` attributes will now display a single unchecked checkbox instead of nothing when a note does not have the attribute defined.
 - Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
 - Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.
 - Fix `boolean` checkboxes being inverted (true as unchecked, false as checked).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for the "include note" feature, allowing views to be embedded in other notes.
 - Add `wrap` attribute setting for table views for enabling text wrapping.
 - `boolean` attributes will now display a single unchecked checkbox instead of nothing when a note does not have the attribute defined.
+- `boolean` checkboxes now look like to-do list checkboxes to better distinguish checked and unchecked when using a dark theme.
 - Fix sticky table cell borders not rendering correctly when scrolling large tables in Trilium 0.47.
 - Fix attribute values not being separated correctly when there are more than two values displayed in a single table cell. Only the last two values would be separated by a space or line break instead of all values.
 - Fix `boolean` checkboxes being inverted (true as unchecked, false as checked).

--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -1,8 +1,8 @@
 const falsyStrings = ["n", "no", "f", "false"];
 
 /**
- * Returns true if some string can be interpreted as false.
+ * Returns true if some string can be interpreted as true.
  */
-export function isFalsy(value: string): boolean {
+export function isTruthy(value: string): boolean {
 	return !falsyStrings.includes(value.trim().toLowerCase());
 }

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -83,6 +83,24 @@ export class AttributeConfig {
 	}
 
 	/**
+	 * Returns an array of elements or text nodes affixed with the configured
+	 * prefix and suffix.
+	 */
+	affixNodes(
+		...$nodes: Array<HTMLElement | Text>
+	): Array<HTMLElement | Text> {
+		const $affixed = [];
+		if (this.prefix) {
+			$affixed.push(document.createTextNode(this.prefix));
+		}
+		$affixed.push(...$nodes);
+		if (this.suffix) {
+			$affixed.push(document.createTextNode(this.suffix));
+		}
+		return $affixed;
+	}
+
+	/**
 	 * Returns the separator to use for multiple attribute values in a table.
 	 */
 	makeSeparator(): HTMLElement | Text {

--- a/src/ui/checkbox.scss
+++ b/src/ui/checkbox.scss
@@ -1,4 +1,29 @@
+$checkbox-size: 1em;
+
 .collection-view-checkbox {
-	width: var(--ck-todo-list-checkmark-size);
-	height: var(--ck-todo-list-checkmark-size);
+	appearance: none;
+	position: relative;
+	border: 1px solid var(--muted-text-color);
+	border-radius: 2px;
+	margin-bottom: -$checkbox-size * 0.15;
+	width: $checkbox-size;
+	height: $checkbox-size;
+
+	&:checked {
+		background: #26ab33 !important;
+
+		&:after {
+			position: absolute;
+			box-sizing: content-box;
+			content: "";
+			left: $checkbox-size / 3;
+			top: $checkbox-size / 5.3;
+			width: $checkbox-size / 5.3;
+			height: $checkbox-size / 2.6;
+			border: solid white;
+			border-width: 0 ($checkbox-size / 8) ($checkbox-size / 8) 0;
+			margin: -1px 0 0 -1px;
+			transform: rotate(45deg);
+		}
+	}
 }

--- a/src/view/BoardView.ts
+++ b/src/view/BoardView.ts
@@ -94,16 +94,17 @@ export class BoardView extends CardView {
 			return $name;
 		}
 
-		let $value = this.renderValue(group.name, groupBy, group.relatedNote);
+		let $nodes = this.renderValue(group.name, groupBy, group.relatedNote);
 		if (group.relatedNote) {
-			$value = (await api.createNoteLink(group.relatedNote.noteId))
+			const $link = (await api.createNoteLink(group.relatedNote.noteId))
 				.find("a")
 				.addClass("stretched-link no-tooltip-preview")
 				.empty()
-				.append($value)[0];
+				.append(...$nodes)[0];
+			$nodes = [$link];
 		}
 
-		$name.appendChild($value);
+		appendChildren($name, $nodes);
 		return $name;
 	}
 

--- a/src/view/CardView.ts
+++ b/src/view/CardView.ts
@@ -107,9 +107,9 @@ export abstract class CardView extends View {
 		attributeConfig: AttributeConfig
 	): Promise<HTMLElement[]> {
 		const $values = await this.renderAttributeValues(note, attributeConfig);
-		return $values.map(($value) => {
+		return $values.map(($nodes) => {
 			const $item = document.createElement("li");
-			$item.appendChild($value);
+			appendChildren($item, $nodes);
 			return $item;
 		});
 	}

--- a/src/view/TableView.scss
+++ b/src/view/TableView.scss
@@ -30,6 +30,7 @@
 .collection-view-table tr > :first-child {
 	position: sticky;
 	left: 0;
+	z-index: 1;
 }
 
 .table.collection-view-table thead th {

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -149,17 +149,14 @@ export class TableView extends View {
 		attributeConfig: AttributeConfig
 	): Promise<Array<HTMLElement | Text>> {
 		const $values = await this.renderAttributeValues(note, attributeConfig);
-		if (attributeConfig.denominatorName) {
-			return $values;
-		}
 
-		const $separatedValues: Array<HTMLElement | Text> = [];
-		$values.forEach(($value, i) => {
-			if (i) {
-				$separatedValues.push(attributeConfig.makeSeparator());
+		const $separated: Array<HTMLElement | Text> = [];
+		$values.forEach(($nodes, i) => {
+			if (!attributeConfig.denominatorName && i) {
+				$separated.push(attributeConfig.makeSeparator());
 			}
-			$separatedValues.push($value);
+			$separated.push(...$nodes);
 		});
-		return $separatedValues;
+		return $separated;
 	}
 }

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -1,7 +1,7 @@
 import { AttributeConfig, ViewConfig } from "collection-views/config";
 import { clamp, numberFormat } from "collection-views/math";
 import { appendChildren } from "collection-views/dom";
-import { isFalsy } from "collection-views/boolean";
+import { isTruthy } from "collection-views/boolean";
 
 /**
  * Base view implementing common rendering of attributes.
@@ -105,10 +105,8 @@ export abstract class View {
 		const $checkbox = document.createElement("input");
 		$checkbox.className = "collection-view-checkbox";
 		$checkbox.type = "checkbox";
+		$checkbox.checked = isTruthy(value);
 		$checkbox.disabled = true;
-		if (!isFalsy(value)) {
-			$checkbox.checked = true;
-		}
 		return $checkbox;
 	}
 

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -24,6 +24,9 @@ export abstract class View {
 		attributeConfig: AttributeConfig
 	): Promise<Array<HTMLElement | Text>> {
 		const attributes = note.getAttributes(undefined, attributeConfig.name);
+		if (attributeConfig.boolean && !attributes.length) {
+			attributes.push({ type: "label", value: "false" });
+		}
 
 		let denominator: string | null = null;
 		if (attributeConfig.denominatorName) {

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -83,7 +83,7 @@ export abstract class View {
 		relatedNote: NoteShort | null
 	): HTMLElement | Text {
 		if (attributeConfig.boolean) {
-			return this.renderBoolean(value);
+			return this.renderBoolean(value, attributeConfig);
 		}
 
 		if (attributeConfig.repeat.trim()) {
@@ -104,13 +104,19 @@ export abstract class View {
 	/**
 	 * Returns an element for rendering an attribute value as a checkbox.
 	 */
-	renderBoolean(value: string): HTMLElement {
+	renderBoolean(
+		value: string,
+		attributeConfig: AttributeConfig
+	): HTMLElement {
 		const $checkbox = document.createElement("input");
 		$checkbox.className = "collection-view-checkbox";
 		$checkbox.type = "checkbox";
 		$checkbox.checked = isTruthy(value);
 		$checkbox.disabled = true;
-		return $checkbox;
+
+		const $span = document.createElement("span");
+		appendChildren($span, attributeConfig.affixNodes($checkbox));
+		return $span;
 	}
 
 	/**
@@ -166,19 +172,14 @@ export abstract class View {
 
 		const $fraction = document.createElement("div");
 		$fraction.className = "collection-view-progress-fraction";
-		if (attributeConfig.prefix) {
-			const $prefix = document.createTextNode(attributeConfig.prefix);
-			$fraction.appendChild($prefix);
-		}
-		appendChildren($fraction, [
-			this.renderProgressBarNumber(numeratorFloat),
-			document.createTextNode(" / "),
-			this.renderProgressBarNumber(denominatorFloat),
-		]);
-		if (attributeConfig.suffix) {
-			const $suffix = document.createTextNode(attributeConfig.suffix);
-			$fraction.appendChild($suffix);
-		}
+		appendChildren(
+			$fraction,
+			attributeConfig.affixNodes(
+				this.renderProgressBarNumber(numeratorFloat),
+				document.createTextNode(" / "),
+				this.renderProgressBarNumber(denominatorFloat)
+			)
+		);
 
 		const $bar = document.createElement("div");
 		$bar.className = "progress-bar";

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -22,7 +22,7 @@ export abstract class View {
 	async renderAttributeValues(
 		note: NoteShort,
 		attributeConfig: AttributeConfig
-	): Promise<Array<HTMLElement | Text>> {
+	): Promise<Array<HTMLElement | Text>[]> {
 		const attributes = note.getAttributes(undefined, attributeConfig.name);
 		if (attributeConfig.boolean && !attributes.length) {
 			attributes.push({ type: "label", value: "false" });
@@ -40,7 +40,7 @@ export abstract class View {
 	}
 
 	/**
-	 * Returns an element or string for rendering an attribute's value.
+	 * Returns elements or strings for rendering an attribute's value.
 	 *
 	 * If a denominator value is given, the attribute's value will be rendered
 	 * as a progress bar.
@@ -49,7 +49,7 @@ export abstract class View {
 		attribute: Attribute,
 		denominator: string | null,
 		attributeConfig: AttributeConfig
-	): Promise<HTMLElement | Text> {
+	): Promise<Array<HTMLElement | Text>> {
 		let relatedNote: NoteShort | null = null;
 		if (attribute.type === "relation") {
 			relatedNote = await api.getNote(attribute.value);
@@ -64,7 +64,7 @@ export abstract class View {
 				attributeConfig
 			);
 			if ($progressBar) {
-				return $progressBar;
+				return [$progressBar];
 			}
 		}
 
@@ -81,7 +81,7 @@ export abstract class View {
 		value: string,
 		attributeConfig: AttributeConfig,
 		relatedNote: NoteShort | null
-	): HTMLElement | Text {
+	): Array<HTMLElement | Text> {
 		if (attributeConfig.boolean) {
 			return this.renderBoolean(value, attributeConfig);
 		}
@@ -95,10 +95,10 @@ export abstract class View {
 		value = attributeConfig.affix(value);
 
 		if (attributeConfig.badge) {
-			return this.renderBadge(value, attributeConfig, relatedNote);
+			return [this.renderBadge(value, attributeConfig, relatedNote)];
 		}
 
-		return document.createTextNode(value);
+		return [document.createTextNode(value)];
 	}
 
 	/**
@@ -107,16 +107,13 @@ export abstract class View {
 	renderBoolean(
 		value: string,
 		attributeConfig: AttributeConfig
-	): HTMLElement {
+	): Array<HTMLElement | Text> {
 		const $checkbox = document.createElement("input");
 		$checkbox.className = "collection-view-checkbox";
 		$checkbox.type = "checkbox";
 		$checkbox.checked = isTruthy(value);
 		$checkbox.disabled = true;
-
-		const $span = document.createElement("span");
-		appendChildren($span, attributeConfig.affixNodes($checkbox));
-		return $span;
+		return attributeConfig.affixNodes($checkbox);
 	}
 
 	/**


### PR DESCRIPTION
- `boolean` attributes will now display a single unchecked checkbox instead of nothing when a note does not have the attribute defined.
- `boolean` checkboxes now look like to-do list checkboxes to better distinguish checked and unchecked when using a dark theme.
- Fix `boolean` checkboxes being inverted (true as unchecked, false as checked).
- Fix `prefix` and `suffix` settings not working with `boolean` checkboxes.