### PR TITLE
Table truncate setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for the "include note" feature, allowing views to be embedded in other notes.
+- Add `truncate` attribute setting for table views for truncating long text to one or more lines.
 - Add `wrap` attribute setting for table views for enabling text wrapping.
 - Improve vertical alignment and spacing of badges.
 - Badges are now normal font weight instead of bold.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
     - [`progressBar`](#progressbar)
     - [`repeat`](#repeat)
     - [`suffix`](#suffix)
+    - [`truncate`](#truncate)
     - [`width`](#width)
     - [`wrap`](#wrap)
   - [Covers](#covers)
@@ -337,6 +338,18 @@ Examples:
 
 - `#attribute="weight,suffix=kg"`
 - `#attribute="price,suffix= CAD"`
+
+#### `truncate`
+
+- Table views only
+- Optional (default: text is not truncated)
+
+Truncates long text to some number of lines. If set as a flag, text is truncated to a single line. Otherwise, the setting's value specifies how many lines. If set, the [`wrap`](#wrap) setting is implicitly enabled.
+
+Examples:
+
+- `#attribute="description,truncate"` (truncate to single line)
+- `#attribute="description,truncate=3"` (truncate to three lines)
 
 #### `width`
 

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -8,6 +8,7 @@ export class AttributeConfig {
 	denominatorName: string = "";
 
 	align: string = "";
+	truncate?: number;
 	width?: number;
 	wrap: boolean = false;
 
@@ -66,6 +67,11 @@ export class AttributeConfig {
 				case "precision":
 					this.number = true;
 					this.precision = parseOptionalInt(value, 0, 20);
+					break;
+
+				case "truncate":
+					this.wrap = true;
+					this.truncate = parseOptionalInt(value || 1, 1, 1000);
 					break;
 
 				case "width":

--- a/src/view/TableView.scss
+++ b/src/view/TableView.scss
@@ -62,3 +62,9 @@
 	margin: 0.25em 0;
 	font-weight: inherit;
 }
+
+.collection-view-truncate {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -133,10 +133,21 @@ export class TableView extends View {
 		if (attributeConfig.wrap) {
 			$cell.style.whiteSpace = "normal";
 		}
-		appendChildren(
-			$cell,
-			await this.renderAttributeCellValues(note, attributeConfig)
+
+		const $values = await this.renderAttributeCellValues(
+			note,
+			attributeConfig
 		);
+		if (attributeConfig.truncate) {
+			const $box = document.createElement("div");
+			$box.className = "collection-view-truncate";
+			$box.style.webkitLineClamp = `${attributeConfig.truncate}`;
+			appendChildren($box, $values);
+			$cell.appendChild($box);
+		} else {
+			appendChildren($cell, $values);
+		}
+
 		return $cell;
 	}
 

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -139,11 +139,7 @@ export class TableView extends View {
 			attributeConfig
 		);
 		if (attributeConfig.truncate) {
-			const $box = document.createElement("div");
-			$box.className = "collection-view-truncate";
-			$box.style.webkitLineClamp = `${attributeConfig.truncate}`;
-			appendChildren($box, $values);
-			$cell.appendChild($box);
+			$cell.appendChild(this.renderTruncated($values, attributeConfig));
 		} else {
 			appendChildren($cell, $values);
 		}
@@ -169,5 +165,20 @@ export class TableView extends View {
 			$separated.push(...$nodes);
 		});
 		return $separated;
+	}
+
+	/**
+	 * Returns content wrapped in a container that truncates the content to the
+	 * number of lines set in the given configuration.
+	 */
+	renderTruncated(
+		$children: Array<HTMLElement | Text>,
+		attributeConfig: AttributeConfig
+	): HTMLElement {
+		const $container = document.createElement("div");
+		$container.className = "collection-view-truncate";
+		$container.style.webkitLineClamp = `${attributeConfig.truncate}`;
+		appendChildren($container, $children);
+		return $container;
 	}
 }


### PR DESCRIPTION
Add `truncate` attribute setting for table views for truncating long text to one or more lines.