### PR TITLE
Margin CSS variable and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 1.1.1 - Unreleased
+## 1.2.0 - Unreleased
 
-- Add margin around all views.
+- Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
   - [Covers](#covers)
   - [Custom badge colors](#custom-badge-colors)
   - [Custom sorting](#custom-sorting)
+  - [CSS variables](#css-variables)
 
 ## Screenshots
 
@@ -392,3 +393,19 @@ This is useful in a couple ways:
 - Ignoring leading articles like "The", "A", or "An". For example, a note titled "The Example" with `#sortableTitle=Example` would appear under E instead of T.
 
 - Numeric sorting. Alphanumerically, "Note 10" would be sorted before "Note 2". If you set `#sortableTitle="Note 02"` on Note 2, then it will appear in numeric order above Note 10.
+
+### CSS variables
+
+The following variables can be changed by [themes](https://github.com/zadam/trilium/wiki/Themes#custom-css-themes) or [custom CSS](https://github.com/zadam/trilium/wiki/Themes#custom-css):
+
+```css
+body {
+  --collection-view-margin: 10px;
+  --collection-view-table-border-color: #bfbfbf;
+}
+```
+
+| Name                                   | Description                              |
+| -------------------------------------- | ---------------------------------------- |
+| `--collection-view-margin`             | Outermost `margin` applied to all views. |
+| `--collection-view-table-border-color` | Table `border-color` for table views.    |

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,4 @@
-body {
+:root {
 	--collection-view-margin: 10px;
 	--collection-view-table-border-color: #bfbfbf;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,5 @@
 body {
+	--collection-view-margin: 10px;
 	--collection-view-table-border-color: #bfbfbf;
 }
 

--- a/src/ui/error.scss
+++ b/src/ui/error.scss
@@ -3,4 +3,8 @@
 	border-radius: 10px;
 	padding: 8px;
 	text-align: center;
+
+	.note-detail-render-content & {
+		margin: var(--collection-view-margin);
+	}
 }

--- a/src/ui/scroll.scss
+++ b/src/ui/scroll.scss
@@ -5,7 +5,7 @@
 	overflow: auto;
 
 	.note-detail-render-content & {
-		margin: 10px;
+		margin: var(--collection-view-margin);
 	}
 
 	.box-size-small & {


### PR DESCRIPTION
* Add `--collection-view-margin` CSS variable for changing the outermost margin. This is set based on Trilium's default themes. Other themes may require different margins.
* Move CSS variables from `body` to `:root` where most default variables are located.
* Add documentation for CSS variables to README.
* Add margin to error message.