### PR TITLE
Custom separators for multiple attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.2.0 - Unreleased
 
+- Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
+  - `separator=newline` inserts a newline between values, resulting in one value per line.
+  - `separator=comma` inserts a comma and space between values.
+  - `separator=space` inserts a space between values.
+  - Any other value will be inserted as is between values, allowing for custom separators.
+- The default separator is now `separator=comma`, except `separator=space` is used for `badge` and `boolean` attributes.
+  - Before, the default was `separator=newline`, except `separator=space` was used for `badge` attributes in table views.
 - Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Any other value will be inserted as is between values, allowing for custom separators.
 - The default separator is now `separator=comma`, except `separator=space` is used for `badge` and `boolean` attributes.
   - Before, the default was `separator=newline`, except `separator=space` was used for `badge` attributes in table views.
+- Escape sequences are now supported in attribute setting values using a backtick as the escape character: <code>``</code> and <code>\`,</code>. This allows for using a comma in settings that accept arbitrary text such as `header`.
 - Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Example: `#attribute="rating,repeat=⭐"`
 
 #### `separator`
 
+- Not supported by [`progressBar`](#progressBar)
 - Optional (default: `space` for `boolean` and `badge` attributes, `comma` otherwise)
 
 Sets the string inserted between values when an attribute has multiple values. This can be one of the following values:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
     - [`precision`](#precision)
     - [`progressBar`](#progressbar)
     - [`repeat`](#repeat)
+    - [`separator`](#separator)
     - [`suffix`](#suffix)
     - [`truncate`](#truncate)
     - [`width`](#width)
@@ -328,6 +329,24 @@ Example: `#attribute="completed,progressBar=total"`
 Renders the value as a string repeated depending on the attribute's numeric value.
 
 Example: `#attribute="rating,repeat=⭐"`
+
+#### `separator`
+
+- Optional (default: `space` for `boolean` and `badge` attributes, `comma` otherwise)
+
+Sets the string inserted between values when an attribute has multiple values. This can be one of the following values:
+
+- `newline`: Inserts a newline between values, resulting in one value per line.
+- `comma`: Inserts a comma and space (`, `) between values.
+- `space`: Inserts a space (` `) between values.
+
+Or, it can be a custom separator. If this setting is not set to one of the above values, then the setting's value will be inserted as is between values.
+
+Examples:
+
+- `#attribute=description,separator=newline`
+- `#attribute=author,separator=comma`
+- `#attribute=tag,separator= | `
 
 #### `suffix`
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
     - [`truncate`](#truncate)
     - [`width`](#width)
     - [`wrap`](#wrap)
+    - [Escape sequences](#escape-sequences)
   - [Covers](#covers)
   - [Custom badge colors](#custom-badge-colors)
   - [Custom sorting](#custom-sorting)
@@ -388,6 +389,17 @@ Example: `#attribute=status,width=100`
 Toggles text wrapping. If enabled, long text in a column will wrap to multiple lines. For tables that scroll horizontally, setting a [`width`](#width) will avoid text getting squashed into a very thin column.
 
 Example: `#attribute=description,wrap`
+
+#### Escape sequences
+
+Escape sequences in setting values begin with a backtick (<code>`</code>). The following escape sequences are supported:
+
+- <code>``</code>: Backtick
+- <code>`,</code>: Comma
+
+Since settings are separated by a comma, the most common use for escape sequences is for escaping a comma so that it can be used literally in a setting that accepts arbitrary text.
+
+Example: <code>#attribute=position,header=X`,Y</code> would display a header containing the text "X,Y".
 
 ### Covers
 

--- a/src/config/AttributeConfig.test.ts
+++ b/src/config/AttributeConfig.test.ts
@@ -110,14 +110,24 @@ describe("AttributeConfig", () => {
 			expect(config.prefix).toBe("  Text  ");
 		});
 
+		test("sets repeat", () => {
+			const config = new AttributeConfig("name,repeat=  Text  ");
+			expect(config.repeat).toBe("Text");
+		});
+
+		test("sets separator", () => {
+			const config = new AttributeConfig("name,separator=  |  ");
+			expect(config.separator).toBe("  |  ");
+		});
+
 		test("sets suffix", () => {
 			const config = new AttributeConfig("name,suffix=  Text  ");
 			expect(config.suffix).toBe("  Text  ");
 		});
 
-		test("sets repeat", () => {
-			const config = new AttributeConfig("name,repeat=  Text  ");
-			expect(config.repeat).toBe("Text");
+		test("handles escape sequences in setting values", () => {
+			const config = new AttributeConfig("name,header=`` `, `x `");
+			expect(config.header).toEqual("` , `x `");
 		});
 	});
 
@@ -159,17 +169,52 @@ describe("AttributeConfig", () => {
 		});
 	});
 
-	describe("makeSeparator", () => {
+	describe("getSeparator", () => {
 		test.each([
 			[
-				"returns space for badges",
+				"returns comma by default for non-badge/Boolean values",
+				"name",
+				document.createTextNode(", "),
+			],
+			[
+				"returns space by default for badges",
 				"name,badge",
 				document.createTextNode(" "),
 			],
-			["returns <br> otherwise", "name", document.createElement("br")],
+			[
+				"returns space by default for Boolean values",
+				"name,boolean",
+				document.createTextNode(" "),
+			],
+			[
+				"returns undefined for empty separator",
+				"name,separator=",
+				undefined,
+			],
+			[
+				"returns comma for comma alias",
+				"name,separator=comma",
+				document.createTextNode(", "),
+			],
+			[
+				"returns space for space alias",
+				"name,separator=space",
+				document.createTextNode(" "),
+			],
+			[
+				"returns <br> for newline alias",
+				"name,separator=newline",
+				document.createElement("br"),
+			],
+			[
+				"returns custom separator",
+				"name,separator= | ",
+				document.createTextNode(" | "),
+			],
 		])("%s", (_, value, expected) => {
 			const config = new AttributeConfig(value);
-			expect(config.makeSeparator()).toEqual(expected);
+			const $separator = config.getSeparator();
+			expect($separator).toEqual(expected);
 		});
 	});
 });

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -1,5 +1,10 @@
 import { parseOptionalInt } from "collection-views/math";
 
+const separatorAliases: Record<string, string> = {
+	comma: ", ",
+	space: " ",
+};
+
 /**
  * Configuration related to an attribute.
  */
@@ -23,8 +28,9 @@ export class AttributeConfig {
 	precision?: number;
 
 	prefix: string = "";
-	suffix: string = "";
 	repeat: string = "";
+	separator?: string;
+	suffix: string = "";
 
 	constructor(value: string) {
 		const options = value.split(",");
@@ -50,6 +56,7 @@ export class AttributeConfig {
 					break;
 
 				case "prefix":
+				case "separator":
 				case "suffix":
 					this[key] = value;
 					break;
@@ -109,10 +116,24 @@ export class AttributeConfig {
 	/**
 	 * Returns the separator to use for multiple attribute values in a table.
 	 */
-	makeSeparator(): HTMLElement | Text {
-		if (this.badge) {
-			return document.createTextNode(" ");
+	getSeparator(): HTMLElement | Text | undefined {
+		if (this.denominatorName) {
+			return undefined;
 		}
-		return document.createElement("br");
+
+		let separator = this.separator;
+		if (separator === undefined) {
+			separator = this.badge || this.boolean ? "space" : "comma";
+		}
+
+		if (!separator) {
+			return undefined;
+		}
+		if (separator === "newline") {
+			return document.createElement("br");
+		}
+		return document.createTextNode(
+			separatorAliases[separator] || separator
+		);
 	}
 }

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -120,10 +120,6 @@ export class AttributeConfig {
 	 * Returns the separator to use for multiple attribute values in a table.
 	 */
 	getSeparator(): HTMLElement | Text | undefined {
-		if (this.denominatorName) {
-			return undefined;
-		}
-
 		let separator = this.separator;
 		if (separator === undefined) {
 			separator = this.badge || this.boolean ? "space" : "comma";

--- a/src/view/CardView.test.ts
+++ b/src/view/CardView.test.ts
@@ -106,16 +106,13 @@ describe("CardView", () => {
 		});
 	});
 
-	describe("renderCardAttributeValues", () => {
-		test("returns list items", async () => {
-			const $items = await view.renderCardAttributeValues(
+	describe("renderCardAttribute", () => {
+		test("returns list item", async () => {
+			const $item = await view.renderCardAttribute(
 				attributeNote,
 				new AttributeConfig("test")
 			);
-
-			expect($items).toHaveLength(2);
-			expect($items[0]).toHaveTextContent("Label 1");
-			expect($items[1]).toHaveTextContent("Label 2");
+			expect($item).toHaveTextContent("Label 1, Label 2");
 		});
 	});
 });

--- a/src/view/CardView.ts
+++ b/src/view/CardView.ts
@@ -64,22 +64,20 @@ export abstract class CardView extends View {
 	async renderCardAttributeList(note: NoteShort): Promise<HTMLElement> {
 		const titlePromise = this.renderCardTitle(note);
 
-		const attributePromises: Promise<HTMLElement[]>[] = [];
+		const attributePromises: Promise<HTMLElement>[] = [];
 		for (const attributeConfig of this.config.attributes) {
 			attributePromises.push(
-				this.renderCardAttributeValues(note, attributeConfig)
+				this.renderCardAttribute(note, attributeConfig)
 			);
 		}
 
 		const $title = await titlePromise;
-		const $attributeValues = await Promise.all(attributePromises);
+		const $attributes = await Promise.all(attributePromises);
 
 		const $list = document.createElement("ul");
 		$list.className = "collection-view-card-attributes";
 		$list.appendChild($title);
-		for (const $values of $attributeValues) {
-			appendChildren($list, $values);
-		}
+		appendChildren($list, $attributes);
 		return $list;
 	}
 
@@ -99,18 +97,17 @@ export abstract class CardView extends View {
 	}
 
 	/**
-	 * Returns elements for rendering list items for a note's attributes in
-	 * a card.
+	 * Returns an element for rendering a list item containing all values of
+	 * a note's attribute.
 	 */
-	async renderCardAttributeValues(
+	async renderCardAttribute(
 		note: NoteShort,
 		attributeConfig: AttributeConfig
-	): Promise<HTMLElement[]> {
+	): Promise<HTMLElement> {
 		const $values = await this.renderAttributeValues(note, attributeConfig);
-		return $values.map(($nodes) => {
-			const $item = document.createElement("li");
-			appendChildren($item, $nodes);
-			return $item;
-		});
+
+		const $item = document.createElement("li");
+		appendChildren($item, $values);
+		return $item;
 	}
 }

--- a/src/view/TableView.test.ts
+++ b/src/view/TableView.test.ts
@@ -163,35 +163,6 @@ describe("TableView", () => {
 		});
 	});
 
-	describe("renderAttributeCellValues", () => {
-		test("returns separated values", async () => {
-			const $values = await view.renderAttributeCellValues(
-				multipleValueNote,
-				new AttributeConfig("test")
-			);
-			expect($values).toHaveLength(3);
-			expect($values[0]).toHaveTextContent("Value 1");
-			expect($values[1]).toEqual(document.createElement("br"));
-			expect($values[2]).toHaveTextContent("Value 2");
-		});
-
-		test("returns progress bars unseparated", async () => {
-			const $values = await view.renderAttributeCellValues(
-				new MockNoteShort({
-					attributes: [
-						{ type: "label", name: "count", value: "1" },
-						{ type: "label", name: "count", value: "2" },
-						{ type: "label", name: "total", value: "2" },
-					],
-				}),
-				new AttributeConfig("count,progressBar=total")
-			);
-			expect($values).toHaveLength(2);
-			expect($values[0]).toHaveTextContent("50%");
-			expect($values[1]).toHaveTextContent("100%");
-		});
-	});
-
 	describe("renderTruncated", () => {
 		test("returns truncated content", () => {
 			const $container = view.renderTruncated(

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -134,10 +134,7 @@ export class TableView extends View {
 			$cell.style.whiteSpace = "normal";
 		}
 
-		const $values = await this.renderAttributeCellValues(
-			note,
-			attributeConfig
-		);
+		const $values = await this.renderAttributeValues(note, attributeConfig);
 		if (attributeConfig.truncate) {
 			$cell.appendChild(this.renderTruncated($values, attributeConfig));
 		} else {
@@ -145,26 +142,6 @@ export class TableView extends View {
 		}
 
 		return $cell;
-	}
-
-	/**
-	 * Returns elements or strings for rendering a note's attributes of the same
-	 * name in a cell.
-	 */
-	async renderAttributeCellValues(
-		note: NoteShort,
-		attributeConfig: AttributeConfig
-	): Promise<Array<HTMLElement | Text>> {
-		const $values = await this.renderAttributeValues(note, attributeConfig);
-
-		const $separated: Array<HTMLElement | Text> = [];
-		$values.forEach(($nodes, i) => {
-			if (!attributeConfig.denominatorName && i) {
-				$separated.push(attributeConfig.makeSeparator());
-			}
-			$separated.push(...$nodes);
-		});
-		return $separated;
 	}
 
 	/**

--- a/src/view/View.test.ts
+++ b/src/view/View.test.ts
@@ -26,10 +26,10 @@ describe("View", () => {
 				new AttributeConfig("test,boolean")
 			);
 			expect($values).toHaveLength(1);
-			expect($values[0][0]).not.toBeChecked();
+			expect($values[0]).not.toBeChecked();
 		});
 
-		test("returns elements for multiple values", async () => {
+		test("returns values separated", async () => {
 			new MockApi({
 				notes: [new MockNoteShort({ noteId: "id", title: "2" })],
 			});
@@ -44,23 +44,26 @@ describe("View", () => {
 				}),
 				new AttributeConfig("test")
 			);
-			expect($values).toHaveLength(2);
-			expect($values[0][0]).toHaveTextContent("1");
-			expect($values[1][0]).toHaveTextContent("2");
+			expect($values).toHaveLength(3);
+			expect($values[0]).toHaveTextContent("1");
+			expect($values[1]).toHaveTextContent(",");
+			expect($values[2]).toHaveTextContent("2");
 		});
 
-		test("returns progress bar element", async () => {
+		test("returns progress bars unseparated", async () => {
 			const $values = await view.renderAttributeValues(
 				new MockNoteShort({
 					attributes: [
 						{ type: "label", name: "count", value: "1" },
+						{ type: "label", name: "count", value: "2" },
 						{ type: "label", name: "total", value: "2" },
 					],
 				}),
 				new AttributeConfig("count,progressBar=total")
 			);
-			expect($values).toHaveLength(1);
-			expect($values[0][0]).toHaveClass("collection-view-progress");
+			expect($values).toHaveLength(2);
+			expect($values[0]).toHaveClass("collection-view-progress");
+			expect($values[1]).toHaveClass("collection-view-progress");
 		});
 	});
 

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -17,12 +17,12 @@ export abstract class View {
 
 	/**
 	 * Returns elements or strings for rendering all values of a note's
-	 * attributes of a certain name.
+	 * attribute with separators between each value.
 	 */
 	async renderAttributeValues(
 		note: NoteShort,
 		attributeConfig: AttributeConfig
-	): Promise<Array<HTMLElement | Text>[]> {
+	): Promise<Array<HTMLElement | Text>> {
 		const attributes = note.getAttributes(undefined, attributeConfig.name);
 		if (attributeConfig.boolean && !attributes.length) {
 			attributes.push({ type: "label", value: "false" });
@@ -33,10 +33,29 @@ export abstract class View {
 			denominator = note.getLabelValue(attributeConfig.denominatorName);
 		}
 
-		const promises = attributes.map((attribute) =>
-			this.renderAttributeValue(attribute, denominator, attributeConfig)
+		const $values = await Promise.all(
+			attributes.map((attribute) =>
+				this.renderAttributeValue(
+					attribute,
+					denominator,
+					attributeConfig
+				)
+			)
 		);
-		return await Promise.all(promises);
+
+		const $separated: Array<HTMLElement | Text> = [];
+		for (let i = 0; i < $values.length; i++) {
+			let $separator;
+			if (i) {
+				$separator = attributeConfig.getSeparator();
+			}
+			if ($separator) {
+				$separated.push($separator);
+			}
+
+			$separated.push(...$values[i]);
+		}
+		return $separated;
 	}
 
 	/**

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -44,9 +44,10 @@ export abstract class View {
 		);
 
 		const $separated: Array<HTMLElement | Text> = [];
+		const separable = !($values[0]?.[0] instanceof HTMLDivElement);
 		for (let i = 0; i < $values.length; i++) {
 			let $separator;
-			if (i) {
+			if (i && separable) {
 				$separator = attributeConfig.getSeparator();
 			}
 			if ($separator) {


### PR DESCRIPTION
- Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
  - `separator=newline` inserts a newline between values, resulting in one value per line.
  - `separator=comma` inserts a comma and space between values.
  - `separator=space` inserts a space between values.
  - Any other value will be inserted as is between values, allowing for custom separators.
- The default separator is now `separator=comma`, except `separator=space` is used for `badge` and `boolean` attributes.
  - Before, the default was `separator=newline`, except `separator=space` was used for `badge` attributes in table views.
- Escape sequences are now supported in attribute setting values using a backtick as the escape character: <code>``</code> and <code>\`,</code>. This allows for using a comma in settings that accept arbitrary text such as `header`.

Resolves #17 