### PR TITLE
Add support for finding note properties and attributes of related notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## 1.2.0 - Unreleased
 
-- Add support for finding attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
-  - Wherever an attribute name can be specified, a path can now be specified instead.
-  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
-  - For example:
-    - `name` would find attributes named `name` defined on a note.
-    - `employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on a note.
-    - `company.employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
 - Add support for finding properties of a note.
   - Wherever an attribute name can be specified, there are now some special names (prefixed with `$`) which refer to a note's properties instead of its user-defined attributes.
   - `$id` and `$noteId` are the note's ID.
@@ -18,6 +11,13 @@
   - `$contentSize` is the size of the note's content in bytes.
   - `$dateCreated` is the note's creation date and time in UTC and RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`).
   - `$dateModified` is the note's modification date and time in UTC and RFC 3339 format.
+- Add support for finding attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
+  - Wherever an attribute name can be specified, a path can now be specified instead.
+  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
+  - For example:
+    - `name` would find attributes named `name` defined on a note.
+    - `employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on a note.
+    - `company.employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
 - Add tokens to `#query` for substituting the Render Note's ID and attributes into the search query.
   - `$id` and `$noteId` will be replaced with the Render Note's ID.
   - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - `$id` and `$noteId` will be replaced with the Render Note's ID.
   - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.
 - `#sort` now supports properties (`#sort="$dateModified"`) and attribute paths (`#sort=relation.label`).
+- `#attribute` now supports properties (`#attribute="$dateModified"`) and attribute paths (`#attribute=relation.label`).
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0 - Unreleased
 
-- Add support for finding properties of a note.
+- Add support for using properties of a note.
   - Wherever an attribute name can be specified, there are now some special names (prefixed with `$`) which refer to a note's properties instead of its user-defined attributes.
   - `$id` and `$noteId` are the note's ID.
   - `$type` is the note type (for example, `text`).
@@ -11,20 +11,20 @@
   - `$contentSize` is the size of the note's content in bytes.
   - `$dateCreated` is the note's creation date and time in UTC and RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`).
   - `$dateModified` is the note's modification date and time in UTC and RFC 3339 format.
-- Add support for finding attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
-  - Wherever an attribute name can be specified, a path can now be specified instead.
-  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
+- Add support for using attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
+  - Wherever an attribute name can be specified, a "path" can now be specified instead.
+  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name or a property name. All other names in the path must be relation names.
   - For example:
     - `name` would find attributes named `name` defined on a note.
     - `employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on a note.
     - `company.employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
 - Add tokens to `#query` for substituting the Render Note's ID and attributes into the search query.
   - `$id` and `$noteId` will be replaced with the Render Note's ID.
-  - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.
-- `#sort` now supports properties (`#sort="$dateModified"`) and attribute paths (`#sort=relation.label`).
-- `#attribute` now supports properties (`#attribute="$dateModified"`) and attribute paths (`#attribute=relation.label`).
-- `#groupBy` now supports properties (`#groupBy="$type"`) attribute paths (`#groupBy=relation.label`).
-- `progressBar` now supports properties (`#attribute="count,progressBar=$contentSize"`) and attribute paths (`#attribute="count,progressBar=relation.total"`).
+  - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note (or an empty string if not found). `name` can be the name of an attribute, a property, or a related note's attribute.
+- `#attribute` now supports properties (`#attribute="$dateModified"`) and attributes of related notes (`#attribute=relation.label`).
+- `#groupBy` now supports properties (`#groupBy="$type"`) and attributes of related notes (`#groupBy=relation.label`).
+- `#sort` now supports properties (`#sort="$dateModified"`) and attributes of related notes (`#sort=relation.label`).
+- `progressBar` now supports properties (`#attribute="count,progressBar=$contentSize"`) and attributes of related notes (`#attribute="count,progressBar=relation.total"`).
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Escape sequences are now supported in attribute setting values using a backtick as the escape character: <code>``</code> and <code>\`,</code>. This allows for using a comma in settings that accept arbitrary text such as `header`.
 - Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
+- Fix `#query` tokens not escaping backslashes and double quotes in values.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.
 
 ## 1.1.0 - 2021-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add tokens to `#query` for substituting the Render Note's ID and attributes into the search query.
   - `$id` and `$noteId` will be replaced with the Render Note's ID.
   - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.
+- `#sort` now supports properties (`#sort="$dateModified"`) and attribute paths (`#sort=relation.label`).
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 1.2.0 - Unreleased
 
+- Add support for finding attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
+  - Wherever an attribute name can be specified, a path can now be specified instead.
+  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
+  - For example:
+    - `name` would find attributes named `name` defined on a note.
+    - `employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on a note.
+    - `company.employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
+- Add support for finding properties of a note.
+  - Wherever an attribute name can be specified, there are now some special names (prefixed with `$`) which refer to a note's properties instead of its user-defined attributes.
+  - `$id` and `$noteId` are the note's ID.
+  - `$type` is the note type (for example, `text`).
+  - `$mime` is the note's content type (for example, `text/html`).
+  - `$title` is the note's title.
+  - `$contentSize` is the size of the note's content in bytes.
+  - `$dateCreated` is the note's creation date and time in UTC and RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`).
+  - `$dateModified` is the note's modification date and time in UTC and RFC 3339 format.
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   - `$contentSize` is the size of the note's content in bytes.
   - `$dateCreated` is the note's creation date and time in UTC and RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`).
   - `$dateModified` is the note's modification date and time in UTC and RFC 3339 format.
+- Add tokens to `#query` for substituting the Render Note's ID and attributes into the search query.
+  - `$id` and `$noteId` will be replaced with the Render Note's ID.
+  - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `#sort` now supports properties (`#sort="$dateModified"`) and attribute paths (`#sort=relation.label`).
 - `#attribute` now supports properties (`#attribute="$dateModified"`) and attribute paths (`#attribute=relation.label`).
 - `#groupBy` now supports properties (`#groupBy="$type"`) attribute paths (`#groupBy=relation.label`).
+- `progressBar` now supports properties (`#attribute="count,progressBar=$contentSize"`) and attribute paths (`#attribute="count,progressBar=relation.total"`).
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note. `name` can be any attribute name, property name, or attribute path.
 - `#sort` now supports properties (`#sort="$dateModified"`) and attribute paths (`#sort=relation.label`).
 - `#attribute` now supports properties (`#attribute="$dateModified"`) and attribute paths (`#attribute=relation.label`).
+- `#groupBy` now supports properties (`#groupBy="$type"`) attribute paths (`#groupBy=relation.label`).
 - Add a `separator` attribute setting for controlling how multiple values for a single attribute are separated:
   - `separator=newline` inserts a newline between values, resulting in one value per line.
   - `separator=comma` inserts a comma and space between values.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Example: `#attribute="price,precision=2"`
 
 Renders a progress bar using the attribute's value as the numerator and another attribute's value (named by this setting's value) as the denominator. Both attributes must be labels with numeric values.
 
+[Note properties](#note-properties) and [attributes of related notes](#attribute-paths) are supported.
+
 Example: `#attribute="completed,progressBar=total"`
 
 #### `repeat`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
     - [`coverHeight`](#coverheight)
     - [`attribute`](#attribute)
   - [Attribute settings](#attribute-settings)
+    - [Note properties](#note-properties)
+    - [Attribute paths](#attribute-paths)
     - [`align`](#align)
     - [`badge`](#badge)
     - [`badgeBackground`](#badgebackground)
@@ -215,6 +217,35 @@ By default, attribute values will be shown as plain text. For labels, the label'
 ### Attribute settings
 
 Labels that support attribute settings ([`#attribute`](#attribute) and [`#groupBy`](#groupBy)) have a value that is a comma-separated list. The first item in the list is an attribute name. Any remaining items in the list are settings (described below) either in the form of a flag (`settingName`) or a key/value pair (`settingName=value`).
+
+#### Note properties
+
+The following special attribute names (prefixed with `$`) refer to a note's properties instead of user-defined attributes:
+
+- `$id` or `$noteId`: The note's ID.
+- `$title`: The note's title.
+- `$type`: The note's type.
+  - As of Trilium v0.58, the possible types are: `book`, `canvas`, `code`, `contentWidget`, `doc`, `file`, `image`, `launcher`, `mermaid`, `noteMap`, `relationMap`, `render`, `search`, `text`, `webView`
+  - The following types existed in older versions of Trilium: `note-map`, `relation-map`, `web-view`
+- `$mime`: The note's content type, such as `text/html`.
+- `$contentSize`: The size of the note's content in bytes.
+- `$dateCreated`: The date and time when the note was created.
+- `$dateModified`: The date and time when the note was last modified.
+
+Date properties use UTC for the time zone and are formatted according to RFC 3339 (`YYYY-MM-DD hh:mm:ss.sssZ`).
+
+Example: `#attribute=$dateModified`
+
+#### Attribute paths
+
+Wherever an attribute name is specified, you can instead provide a path to an attribute. This allows for finding attributes for notes that are targeted by a note's relations.
+
+A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
+
+Examples:
+
+- `#attribute=company.employee.name` would find all attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
+- `#attribute=tag.$dateModified` would find the modification dates of all notes targeted by the `tag` relation defined on a note.
 
 #### `align`
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,21 @@ Example: `#view=board`
 
 A [search query](https://github.com/zadam/trilium/wiki/Search) that will be executed using Trilium's search engine. The notes returned by this search are the notes that will be included in the view.
 
-The substring `$title` will be replaced with the Render Note's title before executing the search.
+The following tokens may be used inside of a search query. Tokens are replaced with attributes or properties of the Render Note prior to executing the search.
+
+- `$id` or `$noteId`: The Render Note's ID.
+- `$title`: The Render Note's title.
+- `$renderNote.name`: An attribute of the Render Note, where `name` can be an attribute name, a [property name](#note-properties), or an [attribute path](#attribute-paths).
+  - If multiple values are found, then the token will be replaced with the first value that was found.
+  - If an attribute is not found, then the token will be replaced with an empty string.
+
+When a token is replaced, the value will be surrounded by double quotes (`"value"`).
 
 Examples:
 
 - `#query="#book #status=read"` would include all notes having a `book` label and a `status` label set to `read`.
-- `#query="~parent.title=$title"` would include all notes having a `parent` relation targeting a note having the same title as the Render Note itself.
+- `#query="#book #status=$renderNote.status"` would include all notes having a `book` label and a `status` label that has the same value as the Render Note's `status` label.
+- `#query="~parent.noteId=$id"` would include all notes having a `parent` relation targeting a note having the same ID as the Render Note itself.
 
 #### `groupBy`
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ By default, attribute values will be shown as plain text. For labels, the label'
 
 ### Attribute settings
 
-Labels that support attribute settings ([`#attribute`](#attribute) and [`#groupBy`](#groupBy)) have a value that is a comma-separated list. The first item in the list is an attribute name. Any remaining items in the list are settings (described below) either in the form of a flag (`settingName`) or a key/value pair (`settingName=value`).
+Labels that support attribute settings ([`#attribute`](#attribute) and [`#groupBy`](#groupBy)) have a value that is a comma-separated list.
+
+The first item in the list is an attribute name, a [property name](#note-properties), or an [attribute path](#attribute-paths). Any remaining items in the list are settings (described below) either in the form of a flag (`settingName`) or a key/value pair (`settingName=value`).
 
 #### Note properties
 
@@ -247,7 +249,7 @@ Example: `#attribute=$dateModified`
 
 #### Attribute paths
 
-Wherever an attribute name is specified, you can instead provide a path to an attribute. This allows for finding attributes for notes that are targeted by a note's relations.
+Wherever an attribute name is specified, you can instead specify a path to an attribute. This allows for finding attributes for notes that are targeted by a note's relations.
 
 A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An extension for [Trilium Notes](https://github.com/zadam/trilium) that implemen
     - [`attribute`](#attribute)
   - [Attribute settings](#attribute-settings)
     - [Note properties](#note-properties)
-    - [Attribute paths](#attribute-paths)
+    - [Attributes of related notes](#attributes-of-related-notes)
     - [`align`](#align)
     - [`badge`](#badge)
     - [`badgeBackground`](#badgebackground)
@@ -127,11 +127,11 @@ Example: `#view=board`
 
 A [search query](https://github.com/zadam/trilium/wiki/Search) that will be executed using Trilium's search engine. The notes returned by this search are the notes that will be included in the view.
 
-The following tokens may be used inside of a search query. Tokens are replaced with attributes or properties of the Render Note prior to executing the search.
+The following tokens may be used inside of a search query. Tokens are replaced with attributes of the Render Note prior to executing the search.
 
 - `$id` or `$noteId`: The Render Note's ID.
 - `$title`: The Render Note's title.
-- `$renderNote.name`: An attribute of the Render Note, where `name` can be an attribute name, a [property name](#note-properties), or an [attribute path](#attribute-paths).
+- `$renderNote.name`: An attribute of the Render Note, where `name` can be the name of an attribute, a [property](#note-properties), or a [related note's attribute](#attributes-of-related-notes).
   - If multiple values are found, then the token will be replaced with the first value that was found.
   - If an attribute is not found, then the token will be replaced with an empty string.
 
@@ -149,14 +149,14 @@ Examples:
 - Required
 - Single value
 
-Determines the columns of the board view. The value of this label is an attribute name.
+Determines the columns of a board view. The value of this label has the same format described in [attribute settings](#attribute-settings).
 
 - If the attribute is a label, then notes are grouped by their values for that label.
-- If the attribute is a relation, then notes are grouped by the notes targeted by the relation.
+- If the attribute is a relation, then notes are grouped by the notes targeted by that relation.
 
 Columns are sorted by the specified attribute. [Custom sorting](#custom-sorting) is supported.
 
-This attribute supports most [attribute settings](#Attribute-settings) for formatting the values displayed in column headers.
+Most attribute settings are supported for formatting the values displayed in column headers.
 
 Examples:
 
@@ -168,10 +168,10 @@ Examples:
 - Optional
 - Single value
 
-Sorts notes in the view. The value of this label is a comma-separated list of attribute names, [property names](#note-properties), or [attribute paths](#attribute-paths). Names and paths can be prefixed with `!` to sort values in descending order.
+Sorts notes in the view. The value of this label is a comma-separated list of names of attributes, [properties](#note-properties), or [attributes of related notes](#attributes-of-related-notes). Names can be prefixed with `!` to sort values in descending order.
 
 - If an attribute is a label, then notes are sorted by their values for that label.
-- If an attribute is a relation, then notes are sorted by the titles of notes targeted by the relation.
+- If an attribute is a relation, then notes are sorted by the titles of notes targeted by that relation.
 
 Values are sorted alphabetically and case-insensitively.
 
@@ -214,24 +214,28 @@ Example: `#coverHeight=500`
 - Optional
 - Multiple values
 
-Configures which note attributes will be displayed in the view and how they should be formatted.
+Configures which attributes will be displayed in the view and how they should be formatted.
 
 - For board and gallery views, attributes appear underneath the cover image.
 - For table views, attributes appear as additional columns in the table.
 
 By default, attribute values will be shown as plain text. For labels, the label's value will be shown. For relations, the titles of target notes will be shown.
 
-[Attribute settings](#Attribute-settings) control how the attribute values are formatted.
+[Attribute settings](#attribute-settings) control how the attribute's values are formatted.
 
 ### Attribute settings
 
 Labels that support attribute settings ([`#attribute`](#attribute) and [`#groupBy`](#groupBy)) have a value that is a comma-separated list.
 
-The first item in the list is an attribute name, a [property name](#note-properties), or an [attribute path](#attribute-paths). Any remaining items in the list are settings (described below) either in the form of a flag (`settingName`) or a key/value pair (`settingName=value`).
+The first item in the list is a name of an attribute, a [property](#note-properties), or a [related note's attribute](#attributes-of-related-notes).
+
+Any remaining items in the list are settings (described in the following sections) either in the form of a flag (`settingName`) or a key/value pair (`settingName=value`).
 
 #### Note properties
 
-The following special attribute names (prefixed with `$`) refer to a note's properties instead of user-defined attributes:
+There are some special attribute names (prefixed with `$`) which refer to a note's properties instead of user-defined attributes.
+
+The following properties are treated as a label with a single value:
 
 - `$id` or `$noteId`: The note's ID.
 - `$title`: The note's title.
@@ -243,15 +247,15 @@ The following special attribute names (prefixed with `$`) refer to a note's prop
 - `$dateCreated`: The date and time when the note was created.
 - `$dateModified`: The date and time when the note was last modified.
 
-Date properties use UTC for the time zone and are formatted according to RFC 3339 (`YYYY-MM-DD hh:mm:ss.sssZ`).
+Date properties are in RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`) and use UTC for the time zone.
 
 Example: `#attribute=$dateModified`
 
-#### Attribute paths
+#### Attributes of related notes
 
-Wherever an attribute name is specified, you can instead specify a path to an attribute. This allows for finding attributes for notes that are targeted by a note's relations.
+Instead of an attribute name, you can specify a "path" that refers to an attribute of a related note. This allows for using attributes of notes that are targeted by a note's relations.
 
-A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name. All other names in the path must be relation names.
+A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name or a [property name](#note-properties). All other names in the path must be relation names.
 
 Examples:
 
@@ -361,11 +365,11 @@ Example: `#attribute="price,precision=2"`
 - Not supported by [`groupBy`](#groupBy)
 - Optional
 
-Renders a progress bar using the attribute's value as the numerator and another attribute's value (named by this setting's value) as the denominator. Both attributes must be labels with numeric values.
+Renders a progress bar. The attribute's value will be the numerator. The value of this setting refers to the attribute whose value will be used as the denominator. It can be the name of an attribute, a [property](#note-properties), or a [related note's attribute](#attributes-of-related-notes).
 
-[Note properties](#note-properties) and [attributes of related notes](#attribute-paths) are supported.
+Both attributes must be labels with numeric values.
 
-Example: `#attribute="completed,progressBar=total"`
+Example: `#attribute="completed,progressBar=total"` — For a note having the attributes `#completed=5 #total=10`, this would display a progress bar that is 50% full.
 
 #### `repeat`
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Examples:
 - Optional
 - Single value
 
-Sorts notes in the view. The value of this label is a comma-separated list of attribute names. Attribute names can be prefixed with `!` to sort values in descending order.
+Sorts notes in the view. The value of this label is a comma-separated list of attribute names, [property names](#note-properties), or [attribute paths](#attribute-paths). Names and paths can be prefixed with `!` to sort values in descending order.
 
 - If an attribute is a label, then notes are sorted by their values for that label.
 - If an attribute is a relation, then notes are sorted by the titles of notes targeted by the relation.

--- a/src/config/AttributeConfig.test.ts
+++ b/src/config/AttributeConfig.test.ts
@@ -10,9 +10,9 @@ describe("AttributeConfig", () => {
 			expect(config.path).toBe(expected);
 		});
 
-		test("sets denominator name from progressBar option", () => {
+		test("sets denominator path from progressBar option", () => {
 			const config = new AttributeConfig("path,progressBar=total");
-			expect(config.denominatorName).toBe("total");
+			expect(config.denominatorPath).toBe("total");
 		});
 
 		test("sets align", () => {

--- a/src/config/AttributeConfig.test.ts
+++ b/src/config/AttributeConfig.test.ts
@@ -4,28 +4,28 @@ describe("AttributeConfig", () => {
 	describe("constructor", () => {
 		test.each([
 			["", ""],
-			["name,options", "name"],
-		])("%p sets name to %p", (value, expected) => {
+			["path,options", "path"],
+		])("%p sets path to %p", (value, expected) => {
 			const config = new AttributeConfig(value);
-			expect(config.name).toBe(expected);
+			expect(config.path).toBe(expected);
 		});
 
 		test("sets denominator name from progressBar option", () => {
-			const config = new AttributeConfig("name,progressBar=total");
+			const config = new AttributeConfig("path,progressBar=total");
 			expect(config.denominatorName).toBe("total");
 		});
 
 		test("sets align", () => {
-			const config = new AttributeConfig("name,align=  left  ");
+			const config = new AttributeConfig("path,align=  left  ");
 			expect(config.align).toBe("left");
 		});
 
 		test.each([
-			["name,truncate", 1],
-			["name,truncate=0", 1],
-			["name,truncate=10.9", 10],
-			["name,truncate=9999", 1000],
-			["name,truncate=bad", undefined],
+			["path,truncate", 1],
+			["path,truncate=0", 1],
+			["path,truncate=10.9", 10],
+			["path,truncate=9999", 1000],
+			["path,truncate=bad", undefined],
 		])("%p sets truncate to %p", (value, expected) => {
 			const config = new AttributeConfig(value);
 			expect(config.truncate).toBe(expected);
@@ -33,18 +33,18 @@ describe("AttributeConfig", () => {
 		});
 
 		test.each([
-			["name,width", undefined],
-			["name,width=-1", 0],
-			["name,width=0", 0],
-			["name,width=10.9", 10],
-			["name,width=9999", 1000],
-			["name,width=bad", undefined],
+			["path,width", undefined],
+			["path,width=-1", 0],
+			["path,width=0", 0],
+			["path,width=10.9", 10],
+			["path,width=9999", 1000],
+			["path,width=bad", undefined],
 		])("%p sets width to %p", (value, expected) => {
 			const config = new AttributeConfig(value);
 			expect(config.width).toBe(expected);
 		});
 
-		test.each(["name,wrap", "name,wrap=anything"])(
+		test.each(["path,wrap", "path,wrap=anything"])(
 			"%p sets wrap to true",
 			(value) => {
 				const config = new AttributeConfig(value);
@@ -53,11 +53,11 @@ describe("AttributeConfig", () => {
 		);
 
 		test("sets header", () => {
-			const config = new AttributeConfig("name,header=  Text  ");
+			const config = new AttributeConfig("path,header=  Text  ");
 			expect(config.header).toBe("Text");
 		});
 
-		test.each(["name,badge", "name,badge=anything"])(
+		test.each(["path,badge", "path,badge=anything"])(
 			"%p sets badge to true",
 			(value) => {
 				const config = new AttributeConfig(value);
@@ -66,18 +66,18 @@ describe("AttributeConfig", () => {
 		);
 
 		test("sets badgeBackground", () => {
-			const config = new AttributeConfig("name,badgeBackground=  red  ");
+			const config = new AttributeConfig("path,badgeBackground=  red  ");
 			expect(config.badge).toBe(true);
 			expect(config.badgeBackground).toBe("red");
 		});
 
 		test("sets badgeColor", () => {
-			const config = new AttributeConfig("name,badgeColor=  red  ");
+			const config = new AttributeConfig("path,badgeColor=  red  ");
 			expect(config.badge).toBe(true);
 			expect(config.badgeColor).toBe("red");
 		});
 
-		test.each(["name,boolean", "name,boolean=anything"])(
+		test.each(["path,boolean", "path,boolean=anything"])(
 			"%p sets boolean to true",
 			(value) => {
 				const config = new AttributeConfig(value);
@@ -85,7 +85,7 @@ describe("AttributeConfig", () => {
 			}
 		);
 
-		test.each(["name,number", "name,number=anything"])(
+		test.each(["path,number", "path,number=anything"])(
 			"%p sets number to true",
 			(value) => {
 				const config = new AttributeConfig(value);
@@ -94,11 +94,11 @@ describe("AttributeConfig", () => {
 		);
 
 		test.each([
-			["name,precision", undefined],
-			["name,precision=-1", 0],
-			["name,precision=0", 0],
-			["name,precision=10.9", 10],
-			["name,precision=99", 20],
+			["path,precision", undefined],
+			["path,precision=-1", 0],
+			["path,precision=0", 0],
+			["path,precision=10.9", 10],
+			["path,precision=99", 20],
 		])("%p sets precision to %p", (value, expected) => {
 			const config = new AttributeConfig(value);
 			expect(config.number).toBe(true);
@@ -106,27 +106,27 @@ describe("AttributeConfig", () => {
 		});
 
 		test("sets prefix", () => {
-			const config = new AttributeConfig("name,prefix=  Text  ");
+			const config = new AttributeConfig("path,prefix=  Text  ");
 			expect(config.prefix).toBe("  Text  ");
 		});
 
 		test("sets repeat", () => {
-			const config = new AttributeConfig("name,repeat=  Text  ");
+			const config = new AttributeConfig("path,repeat=  Text  ");
 			expect(config.repeat).toBe("Text");
 		});
 
 		test("sets separator", () => {
-			const config = new AttributeConfig("name,separator=  |  ");
+			const config = new AttributeConfig("path,separator=  |  ");
 			expect(config.separator).toBe("  |  ");
 		});
 
 		test("sets suffix", () => {
-			const config = new AttributeConfig("name,suffix=  Text  ");
+			const config = new AttributeConfig("path,suffix=  Text  ");
 			expect(config.suffix).toBe("  Text  ");
 		});
 
 		test("handles escape sequences in setting values", () => {
-			const config = new AttributeConfig("name,header=`` `, `x `");
+			const config = new AttributeConfig("path,header=`` `, `x `");
 			expect(config.header).toEqual("` , `x `");
 		});
 	});
@@ -134,7 +134,7 @@ describe("AttributeConfig", () => {
 	describe("affix", () => {
 		test("returns affixed string", () => {
 			const config = new AttributeConfig(
-				"name,prefix=Prefix,suffix=Suffix"
+				"path,prefix=Prefix,suffix=Suffix"
 			);
 			expect(config.affix("Text")).toBe("PrefixTextSuffix");
 		});
@@ -163,7 +163,7 @@ describe("AttributeConfig", () => {
 			],
 		])("%s", (_, prefix, suffix, expected) => {
 			const config = new AttributeConfig(
-				`name,prefix=${prefix},suffix=${suffix}`
+				`path,prefix=${prefix},suffix=${suffix}`
 			);
 			expect(config.affixNodes(...nodes)).toEqual(expected);
 		});
@@ -173,42 +173,42 @@ describe("AttributeConfig", () => {
 		test.each([
 			[
 				"returns comma by default for non-badge/Boolean values",
-				"name",
+				"path",
 				document.createTextNode(", "),
 			],
 			[
 				"returns space by default for badges",
-				"name,badge",
+				"path,badge",
 				document.createTextNode(" "),
 			],
 			[
 				"returns space by default for Boolean values",
-				"name,boolean",
+				"path,boolean",
 				document.createTextNode(" "),
 			],
 			[
 				"returns undefined for empty separator",
-				"name,separator=",
+				"path,separator=",
 				undefined,
 			],
 			[
 				"returns comma for comma alias",
-				"name,separator=comma",
+				"path,separator=comma",
 				document.createTextNode(", "),
 			],
 			[
 				"returns space for space alias",
-				"name,separator=space",
+				"path,separator=space",
 				document.createTextNode(" "),
 			],
 			[
 				"returns <br> for newline alias",
-				"name,separator=newline",
+				"path,separator=newline",
 				document.createElement("br"),
 			],
 			[
 				"returns custom separator",
-				"name,separator= | ",
+				"path,separator= | ",
 				document.createTextNode(" | "),
 			],
 		])("%s", (_, value, expected) => {

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -13,7 +13,7 @@ const separatorAliases: Record<string, string> = {
  */
 export class AttributeConfig {
 	path: string;
-	denominatorName: string = "";
+	denominatorPath: string = "";
 
 	align: string = "";
 	truncate?: number;
@@ -71,7 +71,7 @@ export class AttributeConfig {
 					break;
 
 				case "progressBar":
-					this.denominatorName = value;
+					this.denominatorPath = value;
 					break;
 
 				case "precision":

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -12,7 +12,7 @@ const separatorAliases: Record<string, string> = {
  * Configuration related to an attribute.
  */
 export class AttributeConfig {
-	name: string;
+	path: string;
 	denominatorName: string = "";
 
 	align: string = "";
@@ -37,7 +37,7 @@ export class AttributeConfig {
 
 	constructor(value: string) {
 		const settings = splitComma(value);
-		this.name = settings.shift() || "";
+		this.path = settings.shift() || "";
 
 		for (var setting of settings) {
 			const parts = setting.split("=");

--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -31,8 +31,8 @@ describe("ViewConfig", () => {
 			["clears groupBy if groupBy label is empty", "  ", undefined],
 			[
 				"sets groupBy otherwise",
-				"name,badge",
-				new AttributeConfig("name,badge"),
+				"path,badge",
+				new AttributeConfig("path,badge"),
 			],
 		])("%s", (_, value, expected) => {
 			const config = new ViewConfig(getNote("groupBy", value));

--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -136,6 +136,7 @@ describe("ViewConfig", () => {
 			["#test = $renderNote.relation.label", '#test = "related"'],
 			["#test = $renderNote.bad", '#test = ""'],
 			["#test = $bad", "#test = $bad"],
+			["#test = $renderNote.escape", '#test = "\\\\ \\""'],
 			[
 				"note.id = $id or note.title = $title or #test",
 				'note.id = "1" or note.title = "Note Title" or #test',
@@ -147,6 +148,7 @@ describe("ViewConfig", () => {
 				attributes: [
 					{ type: "label", name: "label", value: "value" },
 					{ type: "label", name: "query", value: rawQuery },
+					{ type: "label", name: "escape", value: '\\ "' },
 					{ type: "relation", name: "relation", value: "2" },
 				],
 			});

--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -45,8 +45,8 @@ describe("ViewConfig", () => {
 				"sets sort otherwise",
 				"  one  ,  !two  ",
 				[
-					{ name: "one", descending: false },
-					{ name: "two", descending: true },
+					{ path: "one", descending: false },
+					{ path: "two", descending: true },
 				],
 			],
 		])("%s", (_, value, expected) => {

--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -1,5 +1,5 @@
-import { MockNoteShort } from "collection-views/test";
 import { AttributeConfig, ViewConfig, ViewType } from "collection-views/config";
+import { MockApi, MockNoteShort } from "collection-views/test";
 
 describe("ViewConfig", () => {
 	describe("constructor", () => {
@@ -20,12 +20,11 @@ describe("ViewConfig", () => {
 			expect(config.view).toBe(expected);
 		});
 
-		test.each([
-			["  #one and #two  ", "#one and #two"],
-			["#title = $title", '#title = "Note Title"'],
-		])("query label %p sets query to %p", (value, expected) => {
-			const config = new ViewConfig(getNote("query", value));
-			expect(config.query).toBe(expected);
+		test("sets query", () => {
+			const config = new ViewConfig(
+				getNote("query", "  #one and #two  ")
+			);
+			expect(config.query).toBe("#one and #two");
 		});
 
 		test.each([
@@ -107,6 +106,54 @@ describe("ViewConfig", () => {
 				new AttributeConfig("one,badge"),
 				new AttributeConfig("two,number"),
 			]);
+		});
+	});
+
+	describe("getQuery", () => {
+		const relatedNote = new MockNoteShort({
+			noteId: "2",
+			attributes: [{ type: "label", name: "label", value: "related" }],
+		});
+
+		beforeEach(() => {
+			new MockApi({ notes: [relatedNote] });
+		});
+
+		test.each([
+			["$id", '"1"'],
+			["#test = $id", '#test = "1"'],
+			["#test = $id.bad", '#test = "1".bad'],
+			["#test = $noteId", '#test = "1"'],
+			["#test = $noteId.bad", '#test = "1".bad'],
+			["#test = $title", '#test = "Note Title"'],
+			["#test = $title.bad", '#test = "Note Title".bad'],
+			["#test = $renderNote", "#test = $renderNote"],
+			["#test = $renderNote.", "#test = $renderNote."],
+			["#test = $renderNote.$", "#test = $renderNote.$"],
+			["#test = $renderNote.$id", '#test = "1"'],
+			["#test = $renderNote.label", '#test = "value"'],
+			["#test = $renderNote.label.", '#test = "value".'],
+			["#test = $renderNote.relation.label", '#test = "related"'],
+			["#test = $renderNote.bad", '#test = ""'],
+			["#test = $bad", "#test = $bad"],
+			[
+				"note.id = $id or note.title = $title or #test",
+				'note.id = "1" or note.title = "Note Title" or #test',
+			],
+		])("query %p returns %p", async (rawQuery, expected) => {
+			const note = new MockNoteShort({
+				noteId: "1",
+				title: "Note Title",
+				attributes: [
+					{ type: "label", name: "label", value: "value" },
+					{ type: "label", name: "query", value: rawQuery },
+					{ type: "relation", name: "relation", value: "2" },
+				],
+			});
+
+			const config = new ViewConfig(note);
+			const query = await config.getQuery();
+			expect(query).toBe(expected);
 		});
 	});
 });

--- a/src/config/ViewConfig.ts
+++ b/src/config/ViewConfig.ts
@@ -1,7 +1,7 @@
 import { parseOptionalInt } from "collection-views/math";
 import {
 	attributePathRegex,
-	getAttributeValue,
+	getAttributeValueByPath,
 	SortAttribute,
 } from "collection-views/notes";
 import { AttributeConfig } from "collection-views/config/AttributeConfig";
@@ -137,8 +137,8 @@ export class ViewConfig {
 	 * - $id: The Render Note's ID.
 	 * - $title: The Render Note's title.
 	 * - $renderNote.path: The value of the first attribute found for the Render
-	 *   Note at "path" (an attribute path; see getAttributes). If no attribute
-	 *   is found, then the value is an empty string.
+	 *   Note at "path" (an attribute path; see getAttributesByPath). If no
+	 *   attribute is found, then the value is an empty string.
 	 *
 	 * All substituted values are double quoted ("value").
 	 */
@@ -164,7 +164,7 @@ export class ViewConfig {
 				path = path.split(".").slice(1).join(".");
 			}
 
-			const value = await getAttributeValue(this.note, path);
+			const value = await getAttributeValueByPath(this.note, path);
 			query += `"${escapeValue(value)}"`;
 			remainder = remainder.slice(length);
 		}

--- a/src/config/ViewConfig.ts
+++ b/src/config/ViewConfig.ts
@@ -134,7 +134,7 @@ export class ViewConfig {
 	 * a value associated with the Render Note. The following tokens are
 	 * supported:
 	 *
-	 * - $id: The Render Note's ID.
+	 * - $id or $noteId: The Render Note's ID.
 	 * - $title: The Render Note's title.
 	 * - $renderNote.path: The value of the first attribute found for the Render
 	 *   Note at "path" (an attribute path; see getAttributesByPath). If no

--- a/src/config/ViewConfig.ts
+++ b/src/config/ViewConfig.ts
@@ -86,16 +86,16 @@ export class ViewConfig {
 			return;
 		}
 
-		this.sort = value.split(",").map((name) => {
-			name = name.trim();
+		this.sort = value.split(",").map((path) => {
+			path = path.trim();
 
 			let descending = false;
-			if (name.startsWith("!")) {
+			if (path.startsWith("!")) {
 				descending = true;
-				name = name.slice(1);
+				path = path.slice(1);
 			}
 
-			return { name, descending };
+			return { path, descending };
 		});
 	}
 

--- a/src/config/ViewConfig.ts
+++ b/src/config/ViewConfig.ts
@@ -165,7 +165,7 @@ export class ViewConfig {
 			}
 
 			const value = await getAttributeValue(this.note, path);
-			query += `"${value}"`;
+			query += `"${escapeValue(value)}"`;
 			remainder = remainder.slice(length);
 		}
 
@@ -193,4 +193,12 @@ function getTokenPrefix(text: string): string | null {
 function getAttributePath(text: string): string | null {
 	const match = text.match(attributePathRegex);
 	return match ? match[0] : null;
+}
+
+/**
+ * Returns a string with all backslashes and double quotes escaped with
+ * a backslash.
+ */
+function escapeValue(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ async function render(): Promise<void> {
 		return;
 	}
 
-	const notes = await api.searchForNotes(config.query);
+	const notes = await api.searchForNotes(await config.getQuery());
 	if (!notes.length) {
 		renderError("No notes found.");
 		return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function render(): Promise<void> {
 				return;
 			}
 
-			const groups = await groupNotes(notes, config.groupBy.name);
+			const groups = await groupNotes(notes, config.groupBy.path);
 			$view = await new BoardView(config, groups).render();
 			break;
 

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -1,7 +1,7 @@
 import {
-	getAttribute,
-	getAttributes,
-	getAttributeValue,
+	getAttributeByPath,
+	getAttributesByPath,
+	getAttributeValueByPath,
 	getCoverUrl,
 	getLabelValueByPath,
 	getSortableAttributeValue,
@@ -40,7 +40,7 @@ const relatedNotes = [
 	}),
 ];
 
-describe("getAttributes", () => {
+describe("getAttributesByPath", () => {
 	beforeEach(() => {
 		new MockApi({ notes: relatedNotes });
 	});
@@ -55,7 +55,7 @@ describe("getAttributes", () => {
 		["returns date created", "$dateCreated", "2020-01-02 03:04:05.678Z"],
 		["returns date modified", "$dateModified", "2020-02-03 04:05:06.789Z"],
 	])("%s", async (_, path, expected) => {
-		const attributes = await getAttributes(attributeNote, path);
+		const attributes = await getAttributesByPath(attributeNote, path);
 		expect(attributes).toHaveLength(1);
 		expect(attributes[0].type).toBe("label");
 		expect(attributes[0].value).toBe(expected);
@@ -88,32 +88,32 @@ describe("getAttributes", () => {
 			[],
 		],
 	])("%s", async (_, path, expected) => {
-		const attributes = await getAttributes(attributeNote, path);
+		const attributes = await getAttributesByPath(attributeNote, path);
 		expect(attributes.map((attribute) => attribute.value)).toEqual(
 			expected
 		);
 	});
 });
 
-describe("getAttribute", () => {
+describe("getAttributeByPath", () => {
 	test("returns first attribute", async () => {
-		const attribute = await getAttribute(attributeNote, "test");
+		const attribute = await getAttributeByPath(attributeNote, "test");
 		expect(attribute).not.toBeNull();
 		expect(attribute?.value).toBe("Label");
 	});
 
 	test("returns null if not found", async () => {
-		const attribute = await getAttribute(attributeNote, "bad");
+		const attribute = await getAttributeByPath(attributeNote, "bad");
 		expect(attribute).toBeNull();
 	});
 });
 
-describe("getAttributeValue", () => {
+describe("getAttributeValueByPath", () => {
 	test.each([
 		["returns value of first attribute", "test", "Label"],
 		["returns empty string if not found", "bad", ""],
 	])("returns %s", async (_, path, expected) => {
-		const value = await getAttributeValue(attributeNote, path);
+		const value = await getAttributeValueByPath(attributeNote, path);
 		expect(value).toBe(expected);
 	});
 });

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -3,6 +3,7 @@ import {
 	getAttributes,
 	getAttributeValue,
 	getCoverUrl,
+	getLabelValueByPath,
 	getSortableAttributeValue,
 	getSortableGroupName,
 	getSortableTitle,
@@ -114,6 +115,26 @@ describe("getAttributeValue", () => {
 	])("returns %s", async (_, path, expected) => {
 		const value = await getAttributeValue(attributeNote, path);
 		expect(value).toBe(expected);
+	});
+});
+
+describe("getLabelValueByPath", () => {
+	test("returns value of first label", async () => {
+		const note = new MockNoteShort({
+			attributes: [
+				{ type: "relation", name: "test", value: "Relation" },
+				{ type: "label", name: "test", value: "Label 1" },
+				{ type: "label", name: "test", value: "Label 2" },
+			],
+		});
+
+		const value = await getLabelValueByPath(note, "test");
+		expect(value).toBe("Label 1");
+	});
+
+	test("returns empty string if not found", async () => {
+		const value = await getLabelValueByPath(attributeNote, "relation");
+		expect(value).toBe("");
 	});
 });
 

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -131,11 +131,11 @@ describe("getCoverUrl", () => {
 });
 
 describe("groupNotes", () => {
-	test("returns an empty array if no notes", async () => {
+	test("returns empty array if no notes", async () => {
 		expect(await groupNotes([], "group")).toEqual([]);
 	});
 
-	test("returns groups otherwise", async () => {
+	test("returns groups for attribute", async () => {
 		const relatedNotes = [
 			new MockNoteShort({ noteId: "1", title: "Note 1" }),
 			new MockNoteShort({
@@ -216,6 +216,43 @@ describe("groupNotes", () => {
 			},
 			{ name: "z", relatedNote: null, notes: [notes[2]] },
 			{ name: undefined, relatedNote: null, notes: [notes[0], notes[1]] },
+		]);
+	});
+
+	test("returns groups for related note's attribute", async () => {
+		const notes = [
+			new MockNoteShort({
+				attributes: [
+					{ type: "relation", name: "relation", value: "1" },
+				],
+			}),
+			new MockNoteShort({
+				attributes: [
+					{ type: "relation", name: "relation", value: "2" },
+				],
+			}),
+		];
+		const relatedNotes = [
+			new MockNoteShort({
+				noteId: "1",
+				attributes: [
+					{ type: "label", name: "label", value: "Label 1" },
+				],
+			}),
+			new MockNoteShort({
+				noteId: "2",
+				attributes: [
+					{ type: "label", name: "label", value: "Label 2" },
+				],
+			}),
+		];
+
+		new MockApi({ notes: relatedNotes });
+
+		const groups = await groupNotes(notes, "relation.label");
+		expect(groups).toEqual([
+			{ name: "Label 1", relatedNote: null, notes: [notes[0]] },
+			{ name: "Label 2", relatedNote: null, notes: [notes[1]] },
 		]);
 	});
 });

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -12,6 +12,111 @@ export interface SortAttribute {
 }
 
 /**
+ * Returns attributes at the given path for the given note.
+ *
+ * A path can either be a single attribute name or multiple names separated by
+ * a period (".").
+ *
+ * If the path is a single attribute name, then this will return all attributes
+ * defined on the given note having that name.
+ *
+ * If the path consists of multiple names, then the last name refers to an
+ * attribute and all other names in the path refer to relations. This will
+ * fetch all notes targeted by those relations, then return all attributes from
+ * those targeted notes having the attribute name.
+ *
+ * For example, the path "x.y.z" would mean:
+ *
+ * 1. Fetch all notes targeted by relation "x" of the given note.
+ * 2. Fetch all notes targeted by relation "y" of all notes from step 1.
+ * 3. Return all "z" attributes of all notes from step 2.
+ *
+ * A name can either be the name of an attribute or one of the special names
+ * listed below. These special names refer to a note's properties instead of
+ * user-defined attributes. Properties are returned in the form of a label.
+ *
+ * - $id or $noteId: The note's ID.
+ * - $type: The note's type (as listed under Note Info such as "text").
+ * - $mime: The note's content type (as listed under Note Info such as
+ *   "text/html").
+ * - $title: The note's title.
+ * - $contentSize: The size of the note's content in bytes.
+ * - $dateCreated: The note's creation date in UTC and RFC 3339 format.
+ * - $dateModified: The note's modification date in UTC and RFC 3339 format.
+ *
+ * If an attribute is not found, then an empty array is returned.
+ *
+ * If a relation refers to a note that does not exist, then it is ignored.
+ */
+export async function getAttributes(
+	note: NoteShort,
+	path: string
+): Promise<Attribute[]> {
+	if (!path) {
+		return [];
+	}
+
+	const parts = path.split(".");
+	if (parts.length > 1) {
+		const attributes = [];
+		const targetPath = parts.slice(1).join(".");
+		for (const target of await note.getRelationTargets(parts[0])) {
+			const targetAttributes = await getAttributes(target, targetPath);
+			attributes.push(...targetAttributes);
+		}
+
+		return attributes;
+	}
+
+	let value: string | undefined;
+	switch (path) {
+		case "$id":
+		case "$noteId":
+			value = note.noteId;
+			break;
+		case "$type":
+			value = note.type;
+			break;
+		case "$mime":
+			value = note.mime;
+			break;
+		case "$title":
+			value = note.title;
+			break;
+		case "$contentSize":
+			value = `${(await note.getNoteComplement()).contentLength}`;
+			break;
+		case "$dateCreated":
+			value = (await note.getNoteComplement()).utcDateCreated;
+			break;
+		case "$dateModified":
+			value = (await note.getNoteComplement()).combinedUtcDateModified;
+			break;
+	}
+	if (value !== undefined) {
+		return [{ type: "label", value }];
+	}
+
+	return note.getAttributes(undefined, path);
+}
+
+/**
+ * Returns the first value of the attribute referenced by the given path that
+ * belong to the given note or notes targeted by the given note's relations.
+ *
+ * See getAttributes for more details.
+ *
+ * If no attributes are found, then an empty string is returned.
+ */
+export async function getAttributeValue(
+	note: NoteShort,
+	name: string
+): Promise<string> {
+	const attributes = await getAttributes(note, name);
+	return attributes[0]?.value || "";
+}
+
+/**
  * Returns the URL for a note's cover image or undefined if it has none.
  */
 export async function getCoverUrl(

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -54,7 +54,7 @@ export interface SortAttribute {
  *
  * If a relation refers to a note that does not exist, then it is ignored.
  */
-export async function getAttributes(
+export async function getAttributesByPath(
 	note: NoteShort,
 	path: string
 ): Promise<Attribute[]> {
@@ -67,8 +67,7 @@ export async function getAttributes(
 		const attributes = [];
 		const targetPath = parts.slice(1).join(".");
 		for (const target of await note.getRelationTargets(parts[0])) {
-			const targetAttributes = await getAttributes(target, targetPath);
-			attributes.push(...targetAttributes);
+			attributes.push(...(await getAttributesByPath(target, targetPath)));
 		}
 
 		return attributes;
@@ -110,13 +109,13 @@ export async function getAttributes(
  * Returns the first attribute referenced by the given path for the given note
  * or null if no attributes are found.
  *
- * See getAttributes for attribute path syntax.
+ * See getAttributesByPath for attribute path syntax.
  */
-export async function getAttribute(
+export async function getAttributeByPath(
 	note: NoteShort,
 	path: string
 ): Promise<Attribute | null> {
-	const attributes = await getAttributes(note, path);
+	const attributes = await getAttributesByPath(note, path);
 	return attributes.length ? attributes[0] : null;
 }
 
@@ -124,13 +123,13 @@ export async function getAttribute(
  * Returns the value of the first attribute referenced by the given path for the
  * given note or an empty string if no attributes are found.
  *
- * See getAttributes for attribute path syntax.
+ * See getAttributesByPath for attribute path syntax.
  */
-export async function getAttributeValue(
+export async function getAttributeValueByPath(
 	note: NoteShort,
 	path: string
 ): Promise<string> {
-	const attribute = await getAttribute(note, path);
+	const attribute = await getAttributeByPath(note, path);
 	return attribute?.value || "";
 }
 
@@ -138,13 +137,13 @@ export async function getAttributeValue(
  * Returns the value of the first label referenced by the given path for the
  * given note or an empty string if no labels are found.
  *
- * See getAttributes for attribute path syntax.
+ * See getAttributesByPath for attribute path syntax.
  */
 export async function getLabelValueByPath(
 	note: NoteShort,
 	path: string
 ): Promise<string> {
-	for (const attribute of await getAttributes(note, path)) {
+	for (const attribute of await getAttributesByPath(note, path)) {
 		if (attribute.type === "label") {
 			return attribute.value;
 		}
@@ -196,7 +195,7 @@ export async function groupNotes(
 	};
 
 	for (const note of notes) {
-		const attributes = await getAttributes(note, path);
+		const attributes = await getAttributesByPath(note, path);
 
 		let addToNone = !attributes.length;
 		const added: AddedFlags = { label: {}, relation: {} };
@@ -328,13 +327,13 @@ export function getSortableGroupName(group: Group): string {
  * If the attribute is a relation, then the related note's sortable title is
  * returned. Otherwise, the attribute's value is returned.
  *
- * See getAttributes for attribute path syntax.
+ * See getAttributesByPath for attribute path syntax.
  */
 export async function getSortableAttributeValue(
 	note: NoteShort,
 	path: string
 ): Promise<string> {
-	const attribute = await getAttribute(note, path);
+	const attribute = await getAttributeByPath(note, path);
 	if (!attribute) {
 		return "";
 	}

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -135,6 +135,24 @@ export async function getAttributeValue(
 }
 
 /**
+ * Returns the value of the first label referenced by the given path for the
+ * given note or an empty string if no labels are found.
+ *
+ * See getAttributes for attribute path syntax.
+ */
+export async function getLabelValueByPath(
+	note: NoteShort,
+	path: string
+): Promise<string> {
+	for (const attribute of await getAttributes(note, path)) {
+		if (attribute.type === "label") {
+			return attribute.value;
+		}
+	}
+	return "";
+}
+
+/**
  * Returns the URL for a note's cover image or undefined if it has none.
  */
 export async function getCoverUrl(

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,5 +1,11 @@
 import { parseFloatStrict } from "collection-views/math";
 
+const attributeNameRegex = "(\\$[a-z]+|[\\w:]+)";
+export const attributePathRegex = new RegExp(
+	`${attributeNameRegex}(\.${attributeNameRegex})*`,
+	"i"
+);
+
 export interface Group {
 	name?: string;
 	relatedNote: NoteShort | null;

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -169,7 +169,7 @@ interface AddedFlags {
  */
 export async function groupNotes(
 	notes: NoteShort[],
-	name: string
+	path: string
 ): Promise<Group[]> {
 	const types: NotesByAttributeType = {
 		label: {},
@@ -178,7 +178,7 @@ export async function groupNotes(
 	};
 
 	for (const note of notes) {
-		const attributes = note.getAttributes(undefined, name);
+		const attributes = await getAttributes(note, path);
 
 		let addToNone = !attributes.length;
 		const added: AddedFlags = { label: {}, relation: {} };

--- a/src/test/trilium.ts
+++ b/src/test/trilium.ts
@@ -69,6 +69,8 @@ interface MockAttribute {
 
 export class MockNoteShort {
 	public noteId: string;
+	public type: string = "text";
+	public mime: string = "text/html";
 	public title: string;
 	private content: string;
 	private attributes: MockAttribute[];
@@ -107,5 +109,25 @@ export class MockNoteShort {
 
 	public getLabelValue(name: string): string | null {
 		return this.getAttribute("label", name)?.value ?? null;
+	}
+
+	public async getNoteComplement(): Promise<NoteComplement> {
+		return {
+			contentLength: 1000,
+			utcDateCreated: "2020-01-02 03:04:05.678Z",
+			combinedUtcDateModified: "2020-02-03 04:05:06.789Z",
+		};
+	}
+
+	public async getRelationTargets(name?: string): Promise<NoteShort[]> {
+		const targets: NoteShort[] = [];
+		for (const attribute of this.getAttributes("relation", name)) {
+			const note = await api.getNote(attribute.value);
+			if (note) {
+				targets.push(note);
+			}
+		}
+
+		return targets;
 	}
 }

--- a/src/trilium.d.ts
+++ b/src/trilium.d.ts
@@ -11,12 +11,22 @@ declare namespace api {
 
 interface NoteShort {
 	noteId: string;
+	type: string;
+	mime: string;
 	title: string;
 	getAttribute(type?: string, name?: string): Attribute | null;
 	getAttributes(type?: string, name?: string): Attribute[];
 	getContent(): Promise<string>;
 	getLabels(name: string): Attribute[];
 	getLabelValue(name: string): string | null;
+	getNoteComplement(): Promise<NoteComplement>;
+	getRelationTargets(name?: string): Promise<NoteShort[]>;
+}
+
+interface NoteComplement {
+	contentLength: number;
+	utcDateCreated: string;
+	combinedUtcDateModified: string;
 }
 
 interface Attribute {

--- a/src/view/TableView.test.ts
+++ b/src/view/TableView.test.ts
@@ -167,7 +167,7 @@ describe("TableView", () => {
 		test("returns truncated content", () => {
 			const $container = view.renderTruncated(
 				[document.createElement("div"), new Text("Content")],
-				new AttributeConfig("name,truncate=3")
+				new AttributeConfig("path,truncate=3")
 			);
 			expect($container).toHaveStyle({ webkitLineClamp: "3" });
 			expect($container).toHaveTextContent("Content");

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -65,7 +65,7 @@ export class TableView extends View {
 	 */
 	renderHeaderCell(attributeConfig: AttributeConfig): HTMLElement {
 		const $cell = document.createElement("th");
-		$cell.textContent = attributeConfig.header || attributeConfig.name;
+		$cell.textContent = attributeConfig.header || attributeConfig.path;
 		if (attributeConfig.align) {
 			$cell.style.textAlign = attributeConfig.align;
 		}

--- a/src/view/View.test.ts
+++ b/src/view/View.test.ts
@@ -26,6 +26,7 @@ describe("View", () => {
 			title: "Title",
 			attributes: [
 				{ type: "label", name: "label", value: "Related label" },
+				{ type: "label", name: "total", value: "3" },
 			],
 		});
 
@@ -69,6 +70,8 @@ describe("View", () => {
 			expect($values).toHaveLength(2);
 			expect($values[0]).toHaveClass("collection-view-progress");
 			expect($values[1]).toHaveClass("collection-view-progress");
+			expect($values[0]).toHaveTextContent("1 / 2");
+			expect($values[1]).toHaveTextContent("2 / 2");
 		});
 
 		test("returns related note's values", async () => {
@@ -78,6 +81,16 @@ describe("View", () => {
 			);
 			expect($values).toHaveLength(1);
 			expect($values[0]).toHaveTextContent("Related label");
+		});
+
+		test("returns progress bar using related note's value", async () => {
+			const $values = await view.renderAttributeValues(
+				note,
+				new AttributeConfig("count,progressBar=test.total")
+			);
+			expect($values).toHaveLength(2);
+			expect($values[0]).toHaveClass("collection-view-progress");
+			expect($values[0]).toHaveTextContent("1 / 3");
 		});
 	});
 

--- a/src/view/View.test.ts
+++ b/src/view/View.test.ts
@@ -12,63 +12,77 @@ const view = new TestView(new ViewConfig(new MockNoteShort()));
 
 describe("View", () => {
 	describe("renderAttributeValues", () => {
+		const note = new MockNoteShort({
+			attributes: [
+				{ type: "label", name: "test", value: "Label" },
+				{ type: "relation", name: "test", value: "1" },
+				{ type: "label", name: "count", value: "1" },
+				{ type: "label", name: "count", value: "2" },
+				{ type: "label", name: "total", value: "2" },
+			],
+		});
+		const relatedNote = new MockNoteShort({
+			noteId: "1",
+			title: "Title",
+			attributes: [
+				{ type: "label", name: "label", value: "Related label" },
+			],
+		});
+
+		beforeEach(() => {
+			new MockApi({ notes: [relatedNote] });
+		});
+
 		test("returns empty array for non-Boolean attribute with no values", async () => {
 			const $values = await view.renderAttributeValues(
-				new MockNoteShort(),
-				new AttributeConfig("test")
+				note,
+				new AttributeConfig("none")
 			);
 			expect($values).toHaveLength(0);
 		});
 
 		test("returns unchecked checkbox for Boolean attribute with no values", async () => {
 			const $values = await view.renderAttributeValues(
-				new MockNoteShort(),
-				new AttributeConfig("test,boolean")
+				note,
+				new AttributeConfig("none,boolean")
 			);
 			expect($values).toHaveLength(1);
 			expect($values[0]).not.toBeChecked();
 		});
 
 		test("returns values separated", async () => {
-			new MockApi({
-				notes: [new MockNoteShort({ noteId: "id", title: "2" })],
-			});
-
 			const $values = await view.renderAttributeValues(
-				new MockNoteShort({
-					attributes: [
-						{ type: "label", name: "test", value: "1" },
-						{ type: "relation", name: "test", value: "id" },
-						{ type: "label", name: "other", value: "3" },
-					],
-				}),
+				note,
 				new AttributeConfig("test")
 			);
 			expect($values).toHaveLength(3);
-			expect($values[0]).toHaveTextContent("1");
+			expect($values[0]).toHaveTextContent("Label");
 			expect($values[1]).toHaveTextContent(",");
-			expect($values[2]).toHaveTextContent("2");
+			expect($values[2]).toHaveTextContent("Title");
 		});
 
 		test("returns progress bars unseparated", async () => {
 			const $values = await view.renderAttributeValues(
-				new MockNoteShort({
-					attributes: [
-						{ type: "label", name: "count", value: "1" },
-						{ type: "label", name: "count", value: "2" },
-						{ type: "label", name: "total", value: "2" },
-					],
-				}),
+				note,
 				new AttributeConfig("count,progressBar=total")
 			);
 			expect($values).toHaveLength(2);
 			expect($values[0]).toHaveClass("collection-view-progress");
 			expect($values[1]).toHaveClass("collection-view-progress");
 		});
+
+		test("returns related note's values", async () => {
+			const $values = await view.renderAttributeValues(
+				note,
+				new AttributeConfig("test.label")
+			);
+			expect($values).toHaveLength(1);
+			expect($values[0]).toHaveTextContent("Related label");
+		});
 	});
 
 	describe("renderAttributeValue", () => {
-		const config = new AttributeConfig("name");
+		const config = new AttributeConfig("path");
 
 		test.each([
 			["returns text for label's value", "label", "Value"],
@@ -121,7 +135,7 @@ describe("View", () => {
 
 		test("returns checkbox for Boolean attribute", () => {
 			const config = new AttributeConfig(
-				"name,boolean,repeat=*,number,badge"
+				"path,boolean,repeat=*,number,badge"
 			);
 
 			const $value = view.renderValue("true", config, null);
@@ -141,7 +155,7 @@ describe("View", () => {
 			["returns text by default", "value", "", "value"],
 		])("%s", (_, value, options, expected) => {
 			const config = new AttributeConfig(
-				`name,prefix=Prefix,suffix=Suffix,${options}`
+				`path,prefix=Prefix,suffix=Suffix,${options}`
 			);
 
 			const $value = view.renderValue(value, config, null);
@@ -155,7 +169,7 @@ describe("View", () => {
 			["returns badge with formatted number", "1000", "number", "1,000"],
 		])("%s", (_, value, options, expected) => {
 			const config = new AttributeConfig(
-				`name,badge,prefix=Prefix,suffix=Suffix,${options}`
+				`path,badge,prefix=Prefix,suffix=Suffix,${options}`
 			);
 
 			const $value = view.renderValue(value, config, note);
@@ -168,14 +182,14 @@ describe("View", () => {
 
 	describe("renderBoolean", () => {
 		test("returns checked checkbox for truthy value", () => {
-			const config = new AttributeConfig("name");
+			const config = new AttributeConfig("path");
 			const $value = view.renderBoolean("true", config);
 			expect($value).toHaveLength(1);
 			expect($value[0]).toBeChecked();
 		});
 
 		test("returns unchecked checkbox for falsy value", () => {
-			const config = new AttributeConfig("name");
+			const config = new AttributeConfig("path");
 			const $value = view.renderBoolean("false", config);
 			expect($value).toHaveLength(1);
 			expect($value[0]).not.toBeChecked();
@@ -183,7 +197,7 @@ describe("View", () => {
 
 		test("returns affixed checkbox", () => {
 			const config = new AttributeConfig(
-				"name,prefix=Prefix,suffix=Suffix"
+				"path,prefix=Prefix,suffix=Suffix"
 			);
 
 			const $value = view.renderBoolean("true", config);
@@ -239,7 +253,7 @@ describe("View", () => {
 				{ color: "black" },
 			],
 		])("%s", (_, options, note, styles) => {
-			const config = new AttributeConfig(`name,${options}`);
+			const config = new AttributeConfig(`path,${options}`);
 			const $badge = view.renderBadge("value", config, note);
 			expect($badge).toHaveTextContent("value");
 			expect($badge).toHaveStyle(styles);
@@ -255,7 +269,7 @@ describe("View", () => {
 			$progress: HTMLElement | undefined;
 			$bar: HTMLElement | null | undefined;
 		} {
-			const config = new AttributeConfig(`name,${options}`);
+			const config = new AttributeConfig(`path,${options}`);
 			const $progress = view.renderProgressBar(
 				numerator,
 				denominator,
@@ -349,7 +363,7 @@ describe("View", () => {
 				"<>".repeat(1000),
 			],
 		])("%s", (_, value, expected) => {
-			const config = new AttributeConfig("name,repeat=<>");
+			const config = new AttributeConfig("path,repeat=<>");
 			const $number = view.formatRepeat(value, config);
 			expect($number).toBe(expected);
 		});
@@ -372,7 +386,7 @@ describe("View", () => {
 				"1,234.567000",
 			],
 		])("%s", (_, value, options, expected) => {
-			const config = new AttributeConfig(`name,${options}`);
+			const config = new AttributeConfig(`path,${options}`);
 			const formatted = view.formatNumber(value, config);
 			expect(formatted).toBe(expected);
 		});

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -1,7 +1,7 @@
 import { AttributeConfig, ViewConfig } from "collection-views/config";
 import { appendChildren } from "collection-views/dom";
 import { clamp, numberFormat } from "collection-views/math";
-import { getAttributes } from "collection-views/notes";
+import { getAttributes, getLabelValueByPath } from "collection-views/notes";
 import { isTruthy } from "collection-views/boolean";
 
 /**
@@ -30,8 +30,11 @@ export abstract class View {
 		}
 
 		let denominator: string | null = null;
-		if (attributeConfig.denominatorName) {
-			denominator = note.getLabelValue(attributeConfig.denominatorName);
+		if (attributeConfig.denominatorPath) {
+			denominator = await getLabelValueByPath(
+				note,
+				attributeConfig.denominatorPath
+			);
 		}
 
 		const $values = await Promise.all(

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -1,6 +1,7 @@
 import { AttributeConfig, ViewConfig } from "collection-views/config";
-import { clamp, numberFormat } from "collection-views/math";
 import { appendChildren } from "collection-views/dom";
+import { clamp, numberFormat } from "collection-views/math";
+import { getAttributes } from "collection-views/notes";
 import { isTruthy } from "collection-views/boolean";
 
 /**
@@ -23,7 +24,7 @@ export abstract class View {
 		note: NoteShort,
 		attributeConfig: AttributeConfig
 	): Promise<Array<HTMLElement | Text>> {
-		const attributes = note.getAttributes(undefined, attributeConfig.name);
+		const attributes = await getAttributes(note, attributeConfig.path);
 		if (attributeConfig.boolean && !attributes.length) {
 			attributes.push({ type: "label", value: "false" });
 		}

--- a/src/view/View.ts
+++ b/src/view/View.ts
@@ -1,7 +1,10 @@
 import { AttributeConfig, ViewConfig } from "collection-views/config";
 import { appendChildren } from "collection-views/dom";
 import { clamp, numberFormat } from "collection-views/math";
-import { getAttributes, getLabelValueByPath } from "collection-views/notes";
+import {
+	getAttributesByPath,
+	getLabelValueByPath,
+} from "collection-views/notes";
 import { isTruthy } from "collection-views/boolean";
 
 /**
@@ -24,7 +27,10 @@ export abstract class View {
 		note: NoteShort,
 		attributeConfig: AttributeConfig
 	): Promise<Array<HTMLElement | Text>> {
-		const attributes = await getAttributes(note, attributeConfig.path);
+		const attributes = await getAttributesByPath(
+			note,
+			attributeConfig.path
+		);
 		if (attributeConfig.boolean && !attributes.length) {
 			attributes.push({ type: "label", value: "false" });
 		}


### PR DESCRIPTION
- Add support for using properties of a note.
  - Wherever an attribute name can be specified, there are now some special names (prefixed with `$`) which refer to a note's properties instead of its user-defined attributes.
  - `$id` and `$noteId` are the note's ID.
  - `$type` is the note type (for example, `text`).
  - `$mime` is the note's content type (for example, `text/html`).
  - `$title` is the note's title.
  - `$contentSize` is the size of the note's content in bytes.
  - `$dateCreated` is the note's creation date and time in UTC and RFC 3339 format (`YYYY-MM-DD hh:mm:ss.sssZ`).
  - `$dateModified` is the note's modification date and time in UTC and RFC 3339 format.
- Add support for using attributes of notes targeted by a note's relations, similar to that supported by [Trilium's search engine](https://github.com/zadam/trilium/wiki/Search#advanced-use-cases).
  - Wherever an attribute name can be specified, a "path" can now be specified instead.
  - A path consists of one or more names separated by a period (`.`). The last name in the path must be an attribute name or a property name. All other names in the path must be relation names.
  - For example:
    - `name` would find attributes named `name` defined on a note.
    - `employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on a note.
    - `company.employee.name` would find attributes named `name` defined on all notes targeted by the `employee` relation defined on all notes targeted by the `company` relation defined on a note.
- Add tokens to `#query` for substituting the Render Note's ID and attributes into the search query.
  - `$id` and `$noteId` will be replaced with the Render Note's ID.
  - `$renderNote.name` will be replaced with the value of the first attribute found for the Render Note (or an empty string if not found). `name` can be the name of an attribute, a property, or a related note's attribute.
- `#attribute` now supports properties (`#attribute="$dateModified"`) and attributes of related notes (`#attribute=relation.label`).
- `#groupBy` now supports properties (`#groupBy="$type"`) and attributes of related notes (`#groupBy=relation.label`).
- `#sort` now supports properties (`#sort="$dateModified"`) and attributes of related notes (`#sort=relation.label`).
- `progressBar` now supports properties (`#attribute="count,progressBar=$contentSize"`) and attributes of related notes (`#attribute="count,progressBar=relation.total"`).

Resolves #20
Resolves #24