### PR TITLE
Fix sizing of scroll containers when using custom theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   - Before, the default was `separator=newline`, except `separator=space` was used for `badge` attributes in table views.
 - Escape sequences are now supported in attribute setting values using a backtick as the escape character: <code>``</code> and <code>\`,</code>. This allows for using a comma in settings that accept arbitrary text such as `header`.
 - Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
+- Fix some cases where the sizing of scrollable containers would cause two vertical scrollbars to display. This could happen when using a custom theme that changes the border, padding, or margin around the note content area.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `#query` tokens not escaping backslashes and double quotes in values.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.

--- a/src/dom.test.ts
+++ b/src/dom.test.ts
@@ -43,11 +43,14 @@ describe("fitToNoteDetailContainer", () => {
 
 	beforeEach(() => {
 		mockApi = new MockApi();
-		mockElementBoundingClientRect(mockApi.$component, { height: 100 });
-
 		$element = document.createElement("div");
-		$element.style.marginTop = "10px";
-		$element.style.marginBottom = "10px";
+
+		jest.spyOn(mockApi.$component, "scrollHeight", "get").mockReturnValue(
+			100
+		);
+		jest.spyOn($element, "scrollHeight", "get").mockReturnValue(80);
+
+		mockElementBoundingClientRect(mockApi.$component, { height: 200 });
 	});
 
 	afterEach(clearBody);
@@ -58,7 +61,7 @@ describe("fitToNoteDetailContainer", () => {
 
 		for (let i = 0; i < 2; i++) {
 			observer.resize(mockApi.$component);
-			expect($element).toHaveStyle({ height: "80px" });
+			expect($element).toHaveStyle({ height: "180px" });
 		}
 	});
 

--- a/src/dom.test.ts
+++ b/src/dom.test.ts
@@ -45,12 +45,11 @@ describe("fitToNoteDetailContainer", () => {
 		mockApi = new MockApi();
 		$element = document.createElement("div");
 
-		jest.spyOn(mockApi.$component, "scrollHeight", "get").mockReturnValue(
-			100
-		);
-		jest.spyOn($element, "scrollHeight", "get").mockReturnValue(80);
-
-		mockElementBoundingClientRect(mockApi.$component, { height: 200 });
+		mockElementBoundingClientRect(mockApi.$component, {
+			y: 100,
+			height: 200,
+		});
+		mockElementBoundingClientRect($element, { y: 120, height: 160.5 });
 	});
 
 	afterEach(clearBody);
@@ -59,9 +58,10 @@ describe("fitToNoteDetailContainer", () => {
 		api.$container.append($element);
 		fitToNoteDetailContainer($element);
 
+		expect($element).toHaveStyle({ minHeight: "" });
 		for (let i = 0; i < 2; i++) {
 			observer.resize(mockApi.$component);
-			expect($element).toHaveStyle({ height: "180px" });
+			expect($element).toHaveStyle({ height: "160px" });
 		}
 	});
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -33,8 +33,19 @@ export function fitToNoteDetailContainer($element: HTMLElement): void {
 		throw new Error("note container element not found");
 	}
 
-	const style = getComputedStyle($element);
-	const margin = parseInt(style.marginTop) + parseInt(style.marginBottom);
+	// The offset is the amount of borders, padding, and margin between the
+	// edges of .scrolling-container and the edges of $element.
+	//
+	// A min-height is temporarily set because $element needs to be at least as
+	// tall as .scrolling-container. Otherwise, empty space due to the content
+	// not filling .scrolling-container would be included in the offset.
+	//
+	// The horizontal scrollbar is temporarily hidden so that its height is not
+	// included in the offset.
+	$element.style.minHeight = "100vh";
+	$element.style.overflowX = "hidden";
+	const offset = $container.scrollHeight - $element.scrollHeight;
+	$element.style.minHeight = $element.style.overflowX = "";
 
 	new ResizeObserver((entries, observer) => {
 		if (!document.body.contains($element)) {
@@ -43,7 +54,7 @@ export function fitToNoteDetailContainer($element: HTMLElement): void {
 		}
 
 		const entry = entries[entries.length - 1];
-		const height = `${Math.floor(entry.contentRect.height - margin)}px`;
+		const height = `${Math.floor(entry.contentRect.height - offset)}px`;
 		if (height === $element.style.height) {
 			return;
 		}

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -40,12 +40,18 @@ export function fitToNoteDetailContainer($element: HTMLElement): void {
 	// tall as .scrolling-container. Otherwise, empty space due to the content
 	// not filling .scrolling-container would be included in the offset.
 	//
-	// The horizontal scrollbar is temporarily hidden so that its height is not
-	// included in the offset.
+	// getBoundingClientRect is the only API which returns non-rounded values.
+	// This is necessary to avoid an extra scrollbar appearing inconsistently
+	// due to rounding causing the $element height to be one pixel too large.
 	$element.style.minHeight = "100vh";
-	$element.style.overflowX = "hidden";
-	const offset = $container.scrollHeight - $element.scrollHeight;
-	$element.style.minHeight = $element.style.overflowX = "";
+	let offset =
+		$element.getBoundingClientRect().top -
+		$container.getBoundingClientRect().top;
+	$container.scrollTop = $container.scrollHeight;
+	offset +=
+		$container.getBoundingClientRect().bottom -
+		$element.getBoundingClientRect().bottom;
+	$element.style.minHeight = "";
 
 	new ResizeObserver((entries, observer) => {
 		if (!document.body.contains($element)) {


### PR DESCRIPTION
- Fix some cases where the sizing of scrollable containers would cause two vertical scrollbars to display. This could happen when using a custom theme that changes the border, padding, or margin around the note content area.