### PR TITLE
Included note fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix some cases where the sizing of scrollable containers would cause two vertical scrollbars to display. This could happen when using a custom theme that changes the border, padding, or margin around the note content area.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `#query` tokens not escaping backslashes and double quotes in values.
+- Fix included notes inside a read-only note having an incorrect height when the included note's box size is set to small or medium in Trilium 0.57+.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.
 
 ## 1.1.0 - 2021-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.
 - Fix `#query` tokens not escaping backslashes and double quotes in values.
 - Fix included notes inside a read-only note having an incorrect height when the included note's box size is set to small or medium in Trilium 0.57+.
+- Fix badges sometimes being misplaced when displayed in an included note inside an editable note.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.
 
 ## 1.1.0 - 2021-07-21

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -72,6 +72,31 @@ export function fitToNoteDetailContainer($element: HTMLElement): void {
 }
 
 /**
+ * Fix display issues when a view is rendered as an included note.
+ */
+export function fixIncludedNote(): void {
+	const $include = api.$container[0].closest(".include-note");
+	if (!($include instanceof HTMLElement)) {
+		return;
+	}
+
+	// Box size is not applied when the current note is read only.
+	$include.classList.add(`box-size-${$include.dataset.boxSize}`);
+
+	let $wrapper = $include.querySelector(".include-note-wrapper");
+	if (!$wrapper) {
+		// Trilium v0.46 to v0.56: Fix content being displayed beside the
+		// included note's title instead of below due to a missing wrapper
+		// element when the current note is read only.
+		$wrapper = document.createElement("div");
+		$wrapper.className = "include-note-wrapper";
+		$wrapper.append(...$include.children);
+		$include.append($wrapper);
+	}
+	$wrapper.classList.add("collection-view-include-note");
+}
+
+/**
  * Renders notes in a staggered manner, appending elements returned from
  * a render function to some parent element.
  *

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,5 @@
+$badge-margin: 0.25em;
+
 :root {
 	--collection-view-margin: 10px;
 	--collection-view-table-border-color: #bfbfbf;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { ViewType, ViewConfig } from "collection-views/config";
-import { fitToNoteDetailContainer, renderError } from "collection-views/dom";
+import {
+	fitToNoteDetailContainer,
+	fixIncludedNote,
+	renderError,
+} from "collection-views/dom";
 import { groupNotes, sortNotes } from "collection-views/notes";
 import { TableView, GalleryView, BoardView } from "collection-views/view";
 
@@ -82,18 +86,7 @@ async function render(): Promise<void> {
 
 	switch (mode) {
 		case RenderMode.Include:
-			const $include = api.$container.closest(".include-note");
-
-			// Fix read-only view DOM inconsistencies.
-			if ($include.children(".include-note-title").length) {
-				const size = $include.data("box-size");
-				const $wrapper = $("<div>").addClass("include-note-wrapper");
-				$include.addClass(`box-size-${size}`).wrapInner($wrapper);
-			}
-
-			$include
-				.children(".include-note-wrapper")
-				.addClass("collection-view-include-note");
+			fixIncludedNote();
 			break;
 
 		case RenderMode.Note:

--- a/src/ui/card.scss
+++ b/src/ui/card.scss
@@ -31,6 +31,11 @@
 	white-space: normal;
 	text-align: left;
 	vertical-align: top;
-	margin: 0.25em 0;
+	margin: $badge-margin 0;
 	font-weight: inherit;
+
+	.note-detail-editable-text &:not(figure):first-child {
+		// Override Trilium forcefully removing margin-top in this case.
+		margin-top: $badge-margin !important;
+	}
 }

--- a/src/view/CardView.test.ts
+++ b/src/view/CardView.test.ts
@@ -92,8 +92,13 @@ describe("CardView", () => {
 
 	describe("renderCardAttributeList", () => {
 		test("returns list", async () => {
-			config.attributes.push(new AttributeConfig("test"));
+			config.attributes.push(
+				new AttributeConfig("test"),
+				new AttributeConfig("bad")
+			);
+
 			const $list = await view.renderCardAttributeList(attributeNote);
+			expect($list.children).toHaveLength(2);
 			expect($list).toHaveTextContent("Title");
 			expect($list).toHaveTextContent("Label");
 		});
@@ -113,6 +118,14 @@ describe("CardView", () => {
 				new AttributeConfig("test")
 			);
 			expect($item).toHaveTextContent("Label 1, Label 2");
+		});
+
+		test("returns null if attribute not found", async () => {
+			const $item = await view.renderCardAttribute(
+				attributeNote,
+				new AttributeConfig("bad")
+			);
+			expect($item).toBeNull();
 		});
 	});
 });

--- a/src/view/CardView.ts
+++ b/src/view/CardView.ts
@@ -63,8 +63,7 @@ export abstract class CardView extends View {
 	 */
 	async renderCardAttributeList(note: NoteShort): Promise<HTMLElement> {
 		const titlePromise = this.renderCardTitle(note);
-
-		const attributePromises: Promise<HTMLElement>[] = [];
+		const attributePromises: Promise<HTMLElement | null>[] = [];
 		for (const attributeConfig of this.config.attributes) {
 			attributePromises.push(
 				this.renderCardAttribute(note, attributeConfig)
@@ -72,7 +71,13 @@ export abstract class CardView extends View {
 		}
 
 		const $title = await titlePromise;
-		const $attributes = await Promise.all(attributePromises);
+		const $attributes: HTMLElement[] = [];
+		for (const promise of attributePromises) {
+			const $attribute = await promise;
+			if ($attribute) {
+				$attributes.push($attribute);
+			}
+		}
 
 		const $list = document.createElement("ul");
 		$list.className = "collection-view-card-attributes";
@@ -98,13 +103,16 @@ export abstract class CardView extends View {
 
 	/**
 	 * Returns an element for rendering a list item containing all values of
-	 * a note's attribute.
+	 * a note's attribute, or null if there are no values.
 	 */
 	async renderCardAttribute(
 		note: NoteShort,
 		attributeConfig: AttributeConfig
-	): Promise<HTMLElement> {
+	): Promise<HTMLElement | null> {
 		const $values = await this.renderAttributeValues(note, attributeConfig);
+		if (!$values.length) {
+			return null;
+		}
 
 		const $item = document.createElement("li");
 		appendChildren($item, $values);

--- a/src/view/TableView.scss
+++ b/src/view/TableView.scss
@@ -59,8 +59,13 @@
 
 .collection-view-table .badge {
 	vertical-align: top;
-	margin: 0.25em 0;
+	margin: $badge-margin 0;
 	font-weight: inherit;
+
+	.note-detail-editable-text &:not(figure):first-child {
+		// Override Trilium forcefully removing margin-top in this case.
+		margin-top: $badge-margin !important;
+	}
 }
 
 .collection-view-truncate {


### PR DESCRIPTION
- Fix included notes inside a read-only note having an incorrect height when the included note's box size is set to small or medium in Trilium 0.57+.
- Fix badges sometimes being misplaced when displayed in an included note inside an editable note.
- Fix a regression with cards causing excess space to display in an included note when an attribute has no values.