### PR TITLE
Cover fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 - Fix included notes inside a read-only note having an incorrect height when the included note's box size is set to small or medium in Trilium 0.57+.
 - Fix badges sometimes being misplaced when displayed in an included note inside an editable note.
 - Fix `boolean` checkbox styles not being applied in Trilium 0.46.
+- Fix an error that occurs when attempting to display a cover image for image notes and web-view notes.
+- Content of non-text notes is no longer inspected for covers which may reduce memory and bandwidth usage.
 
 ## 1.1.0 - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - The default separator is now `separator=comma`, except `separator=space` is used for `badge` and `boolean` attributes.
   - Before, the default was `separator=newline`, except `separator=space` was used for `badge` attributes in table views.
 - Escape sequences are now supported in attribute setting values using a backtick as the escape character: <code>``</code> and <code>\`,</code>. This allows for using a comma in settings that accept arbitrary text such as `header`.
+- Board and gallery views will now display a cover image for image notes (uploaded image files). The image itself will be used as its cover.
 - Add margin around all views to better align the edges of views when using Trilium's default themes. This can be changed using the `--collection-view-margin` CSS variable.
 - Fix some cases where the sizing of scrollable containers would cause two vertical scrollbars to display. This could happen when using a custom theme that changes the border, padding, or margin around the note content area.
 - Fix "ResizeObserver loop limit exceeded" errors occurring in console when the note content area is resized.

--- a/README.md
+++ b/README.md
@@ -452,7 +452,11 @@ Example: <code>#attribute=position,header=X`,Y</code> would display a header con
 
 ### Covers
 
-The board and gallery views display an optional cover image for each note. The first image found in the note's contents is used as the cover.
+The board and gallery views display an optional cover image for each note.
+
+- For text notes, the first image found in the note's contents will be used as the cover.
+- For image notes (image files uploaded to Trilium), the image itself will be displayed as the cover.
+- For other note types, no cover will be displayed.
 
 ### Custom badge colors
 

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -140,14 +140,28 @@ describe("getLabelValueByPath", () => {
 
 describe("getCoverUrl", () => {
 	test.each([
+		[undefined, undefined],
 		["<p></p>", undefined],
 		[
-			'<p>text</p><img src="api/images/cover.png"><img src="ignore.png">',
-			"api/images/cover.png",
+			`<p>text</p>
+			<img src="api/images/id/cover.png">
+			<img src="ignore.png">`,
+			"api/images/id/cover.png",
 		],
-	])("%p returns %p", async (content, expected) => {
+	])("text note content %p returns %p", async (content, expected) => {
 		const note = new MockNoteShort({ content });
-		expect(await getCoverUrl(note)).toBe(expected);
+		const url = await getCoverUrl(note);
+		expect(url).toBe(expected);
+	});
+
+	test("returns undefined for other note types", async () => {
+		const note = new MockNoteShort({
+			type: "code",
+			content: '<img src="image.png">',
+		});
+
+		const url = await getCoverUrl(note);
+		expect(url).toBeUndefined();
 	});
 });
 

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -139,6 +139,17 @@ describe("getLabelValueByPath", () => {
 });
 
 describe("getCoverUrl", () => {
+	test("returns URL for image note", async () => {
+		const note = new MockNoteShort({
+			noteId: "id",
+			type: "image",
+			title: "test/../image.png",
+		});
+
+		const url = await getCoverUrl(note);
+		expect(url).toBe("api/images/id/test%2F..%2Fimage.png");
+	});
+
 	test.each([
 		[undefined, undefined],
 		["<p></p>", undefined],

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -157,8 +157,12 @@ export async function getLabelValueByPath(
 export async function getCoverUrl(
 	note: NoteShort
 ): Promise<string | undefined> {
-	const content = await note.getContent();
-	if (!content.includes("<img")) {
+	if (note.type !== "text") {
+		return undefined;
+	}
+
+	const content = (await note.getNoteComplement()).content;
+	if (!content?.includes("<img")) {
 		return undefined;
 	}
 

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -157,6 +157,9 @@ export async function getLabelValueByPath(
 export async function getCoverUrl(
 	note: NoteShort
 ): Promise<string | undefined> {
+	if (note.type === "image") {
+		return `api/images/${note.noteId}/${encodeURIComponent(note.title)}`;
+	}
 	if (note.type !== "text") {
 		return undefined;
 	}

--- a/src/test/trilium.ts
+++ b/src/test/trilium.ts
@@ -56,6 +56,7 @@ export class MockApi {
 
 interface NoteShortProps {
 	noteId?: string;
+	type?: string;
 	title?: string;
 	content?: string;
 	attributes?: MockAttribute[];
@@ -69,19 +70,21 @@ interface MockAttribute {
 
 export class MockNoteShort {
 	public noteId: string;
-	public type: string = "text";
+	public type: string;
 	public mime: string = "text/html";
 	public title: string;
-	private content: string;
+	private content?: string;
 	private attributes: MockAttribute[];
 
 	constructor({
 		noteId = "",
+		type = "text",
 		title = "",
-		content = "",
+		content,
 		attributes = [],
 	}: NoteShortProps = {}) {
 		this.noteId = noteId;
+		this.type = type;
 		this.title = title;
 		this.content = content;
 		this.attributes = attributes;
@@ -99,10 +102,6 @@ export class MockNoteShort {
 		);
 	}
 
-	public async getContent(): Promise<string> {
-		return this.content;
-	}
-
 	public getLabels(name: string): Attribute[] {
 		return this.getAttributes("label", name);
 	}
@@ -113,6 +112,7 @@ export class MockNoteShort {
 
 	public async getNoteComplement(): Promise<NoteComplement> {
 		return {
+			content: this.content,
 			contentLength: 1000,
 			utcDateCreated: "2020-01-02 03:04:05.678Z",
 			combinedUtcDateModified: "2020-02-03 04:05:06.789Z",

--- a/src/trilium.d.ts
+++ b/src/trilium.d.ts
@@ -16,7 +16,6 @@ interface NoteShort {
 	title: string;
 	getAttribute(type?: string, name?: string): Attribute | null;
 	getAttributes(type?: string, name?: string): Attribute[];
-	getContent(): Promise<string>;
 	getLabels(name: string): Attribute[];
 	getLabelValue(name: string): string | null;
 	getNoteComplement(): Promise<NoteComplement>;
@@ -24,6 +23,7 @@ interface NoteShort {
 }
 
 interface NoteComplement {
+	content?: string;
 	contentLength: number;
 	utcDateCreated: string;
 	combinedUtcDateModified: string;


### PR DESCRIPTION
- Board and gallery views will now display a cover image for image notes (uploaded image files). The image itself will be used as its cover.
- Fix an error that occurs when attempting to display a cover image for image notes and web-view notes.
- Content of non-text notes is no longer inspected for covers which may reduce memory and bandwidth usage.