### PR TITLE
Fix `$renderNote` token being parsed incorrectly when not at end of query

### DIFF
--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -141,6 +141,10 @@ describe("ViewConfig", () => {
 				"note.id = $id or note.title = $title or #test",
 				'note.id = "1" or note.title = "Note Title" or #test',
 			],
+			[
+				"note.label = $renderNote.relation.label and #test",
+				'note.label = "related" and #test',
+			],
 		])("query %p returns %p", async (rawQuery, expected) => {
 			const note = new MockNoteShort({
 				noteId: "1",

--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -138,12 +138,12 @@ describe("ViewConfig", () => {
 			["#test = $bad", "#test = $bad"],
 			["#test = $renderNote.escape", '#test = "\\\\ \\""'],
 			[
-				"note.id = $id or note.title = $title or #test",
-				'note.id = "1" or note.title = "Note Title" or #test',
+				"note.noteId = $id or note.title = $title or #test",
+				'note.noteId = "1" or note.title = "Note Title" or #test',
 			],
 			[
-				"note.label = $renderNote.relation.label and #test",
-				'note.label = "related" and #test',
+				"#label = $renderNote.relation.label and #test",
+				'#label = "related" and #test',
 			],
 		])("query %p returns %p", async (rawQuery, expected) => {
 			const note = new MockNoteShort({

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -2,7 +2,7 @@ import { parseFloatStrict } from "collection-views/math";
 
 const attributeNameRegex = "(\\$[a-z]+|[\\w:]+)";
 export const attributePathRegex = new RegExp(
-	`${attributeNameRegex}(\.${attributeNameRegex})*`,
+	`${attributeNameRegex}(\\.${attributeNameRegex})*`,
 	"i"
 );
 


### PR DESCRIPTION
For example, the query `#one=$renderNote.label and #two` would incorrectly substitute `$renderNote.label and` as a token instead of `$renderNote.label`.