### PR TITLE
Fix error with query tokens in Trilium 0.46

### DIFF
--- a/src/config/ViewConfig.test.ts
+++ b/src/config/ViewConfig.test.ts
@@ -136,7 +136,7 @@ describe("ViewConfig", () => {
 			["#test = $renderNote.relation.label", '#test = "related"'],
 			["#test = $renderNote.bad", '#test = ""'],
 			["#test = $bad", "#test = $bad"],
-			["#test = $renderNote.escape", '#test = "\\\\ \\""'],
+			["#test = $renderNote.escape", '#test = "\\\\ \\" \\\\ \\""'],
 			[
 				"note.noteId = $id or note.title = $title or #test",
 				'note.noteId = "1" or note.title = "Note Title" or #test',
@@ -152,7 +152,7 @@ describe("ViewConfig", () => {
 				attributes: [
 					{ type: "label", name: "label", value: "value" },
 					{ type: "label", name: "query", value: rawQuery },
-					{ type: "label", name: "escape", value: '\\ "' },
+					{ type: "label", name: "escape", value: '\\ " \\ "' },
 					{ type: "relation", name: "relation", value: "2" },
 				],
 			});

--- a/src/config/ViewConfig.ts
+++ b/src/config/ViewConfig.ts
@@ -200,5 +200,6 @@ function getAttributePath(text: string): string | null {
  * a backslash.
  */
 function escapeValue(value: string): string {
-	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+	// TODO: Use replaceAll when Trilium 0.46 is dropped.
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }


### PR DESCRIPTION
- Fix a regression causing an error when using query tokens in Trilium 0.46 (`String.replaceAll` is not supported).