### PR TITLE
Fix `header` cell showing attribute name when set to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 - Unreleased
 
 - Fix scrolling issues (double scrollbar and scrolling down on load) that occur in Trilium v0.60+.
+- Fix the `header` attribute setting displaying the attribute name instead of an empty header cell when set to an empty value (`#attribute=name,header=`).
 
 ## 1.2.0 - 2023-01-22
 

--- a/src/config/AttributeConfig.test.ts
+++ b/src/config/AttributeConfig.test.ts
@@ -52,9 +52,13 @@ describe("AttributeConfig", () => {
 			}
 		);
 
-		test("sets header", () => {
-			const config = new AttributeConfig("path,header=  Text  ");
-			expect(config.header).toBe("Text");
+		test.each([
+			["path,header", ""],
+			["path,header=", ""],
+			["path,header=  Text  ", "Text"],
+		])("%p sets header to %p", (value, expected) => {
+			const config = new AttributeConfig(value);
+			expect(config.header).toBe(expected);
 		});
 
 		test.each(["path,badge", "path,badge=anything"])(
@@ -127,7 +131,7 @@ describe("AttributeConfig", () => {
 
 		test("handles escape sequences in setting values", () => {
 			const config = new AttributeConfig("path,header=`` `, `x `");
-			expect(config.header).toEqual("` , `x `");
+			expect(config.header).toBe("` , `x `");
 		});
 	});
 

--- a/src/config/AttributeConfig.ts
+++ b/src/config/AttributeConfig.ts
@@ -20,7 +20,7 @@ export class AttributeConfig {
 	width?: number;
 	wrap: boolean = false;
 
-	header: string = "";
+	header?: string;
 
 	badge: boolean = false;
 	badgeBackground: string = "";

--- a/src/view/TableView.test.ts
+++ b/src/view/TableView.test.ts
@@ -75,6 +75,13 @@ describe("TableView", () => {
 			expect($cell).toHaveTextContent("test");
 		});
 
+		test("returns table cell with empty header text", () => {
+			const $cell = view.renderHeaderCell(
+				new AttributeConfig("test,header=")
+			);
+			expect($cell).toBeEmptyDOMElement();
+		});
+
 		test("returns table cell with custom header text", () => {
 			const $cell = view.renderHeaderCell(
 				new AttributeConfig("test,header=Header")

--- a/src/view/TableView.ts
+++ b/src/view/TableView.ts
@@ -65,7 +65,7 @@ export class TableView extends View {
 	 */
 	renderHeaderCell(attributeConfig: AttributeConfig): HTMLElement {
 		const $cell = document.createElement("th");
-		$cell.textContent = attributeConfig.header || attributeConfig.path;
+		$cell.textContent = attributeConfig.header ?? attributeConfig.path;
 		if (attributeConfig.align) {
 			$cell.style.textAlign = attributeConfig.align;
 		}


### PR DESCRIPTION
- Fix the `header` attribute setting displaying the attribute name instead of an empty header cell when set to an empty value (`#attribute=name,header=`).

Fixes #40