### PR TITLE
Fix `$dateCreated` and `$dateModified` being empty in Trilium v0.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.2.1 - Unreleased
 
 - Fix scrolling issues (double scrollbar and scrolling down on load) that occur in Trilium v0.60+.
+- Fix the `$dateCreated` and `$dateModified` properties displaying an empty value in Trilium v0.61+.
+  - For Trilium v0.61.0 to v0.61.5, `$dateCreated` is not available and `$dateModified` will display the modification date of the note's content and not the note itself.
+  - If you are using the v0.61 beta, upgrade to at least v0.61.6 for these dates to work as intended.
 - Fix the `header` attribute setting displaying the attribute name instead of an empty header cell when set to an empty value (`#attribute=name,header=`).
 
 ## 1.2.0 - 2023-01-22

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -166,24 +166,37 @@ describe("getCoverUrl", () => {
 	});
 
 	test.each([
-		["returns undefined if content is undefined", undefined, undefined],
-		["returns undefined if no image in content", "<p></p>", undefined],
+		[
+			"returns undefined if content is undefined",
+			new MockNoteShort(),
+			undefined,
+		],
+		["returns undefined if content is null", new MockFNote(), undefined],
+		[
+			"returns undefined if no image in content",
+			new MockFNote({ content: "<p></p>" }),
+			undefined,
+		],
 		[
 			"returns URL if content references image note",
-			`<p>text</p>
-			<img src="api/images/id/cover.png">
-			<img src="ignore.png">`,
+			new MockFNote({
+				content: `
+					<p>text</p>
+					<img src="api/images/id/cover.png">
+					<img src="ignore.png">
+				`,
+			}),
 			"api/images/id/cover.png",
 		],
 		[
 			"returns URL if content references image attachment",
-			'<img src="api/attachments/id/image/cover.png">',
+			new MockFNote({
+				content: '<img src="api/attachments/id/image/cover.png">',
+			}),
 			"api/attachments/id/image/cover.png",
 		],
-	])("%s", async (_, content, expected) => {
-		const note = new MockNoteShort({ content });
-		const url = await getCoverUrl(note);
-		expect(url).toBe(expected);
+	])("%s", async (_, note, expected) => {
+		expect(await getCoverUrl(note)).toBe(expected);
 	});
 
 	test("returns undefined for other note types", async () => {
@@ -630,7 +643,7 @@ describe("getSortableTitle", () => {
 describe("getContent", () => {
 	test.each([
 		[
-			"returns null if content of note's blob is undefined",
+			"returns null if content of note's blob is null",
 			new MockFNote(),
 			null,
 		],

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -166,15 +166,21 @@ describe("getCoverUrl", () => {
 	});
 
 	test.each([
-		[undefined, undefined],
-		["<p></p>", undefined],
+		["returns undefined if content is undefined", undefined, undefined],
+		["returns undefined if no image in content", "<p></p>", undefined],
 		[
+			"returns URL if content references image note",
 			`<p>text</p>
 			<img src="api/images/id/cover.png">
 			<img src="ignore.png">`,
 			"api/images/id/cover.png",
 		],
-	])("text note content %p returns %p", async (content, expected) => {
+		[
+			"returns URL if content references image attachment",
+			'<img src="api/attachments/id/image/cover.png">',
+			"api/attachments/id/image/cover.png",
+		],
+	])("%s", async (_, content, expected) => {
 		const note = new MockNoteShort({ content });
 		const url = await getCoverUrl(note);
 		expect(url).toBe(expected);

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -374,7 +374,7 @@ export function getSortableTitle(note: NoteShort): string {
 export async function getContent(note: NoteShort): Promise<string | null> {
 	if (note.getBlob) {
 		// Available since Trilium v0.61.
-		return (await note.getBlob()).content ?? null;
+		return (await note.getBlob()).content;
 	}
 	if (note.getNoteComplement) {
 		// Deprecated since Trilium v0.61.

--- a/src/test/trilium.ts
+++ b/src/test/trilium.ts
@@ -59,7 +59,7 @@ interface NoteShortProps {
 	noteId?: string;
 	type?: string;
 	title?: string;
-	content?: string;
+	content?: string | null;
 	contentLength?: number;
 	attributes?: MockAttribute[];
 }
@@ -75,7 +75,7 @@ abstract class BaseMockFNote {
 	public type: string;
 	public mime: string = "text/html";
 	public title: string;
-	protected content?: string;
+	protected content: string | null;
 	protected contentLength: number;
 	protected dateCreated: string = "2020-01-02 03:04:05.678Z";
 	protected dateModified: string = "2020-02-03 04:05:06.789Z";
@@ -85,7 +85,7 @@ abstract class BaseMockFNote {
 		noteId = "",
 		type = "text",
 		title = "",
-		content,
+		content = null,
 		contentLength = 1000,
 		attributes = [],
 	}: NoteShortProps = {}) {
@@ -165,7 +165,7 @@ export class MockFNote extends MockFNote0615 {
 export class MockNoteShort extends BaseMockFNote {
 	public async getNoteComplement(): Promise<NoteComplement> {
 		return {
-			content: this.content,
+			content: this.content ?? undefined,
 			contentLength: this.contentLength,
 			utcDateCreated: this.dateCreated,
 			combinedUtcDateModified: this.dateModified,

--- a/src/trilium.d.ts
+++ b/src/trilium.d.ts
@@ -16,12 +16,28 @@ interface NoteShort {
 	title: string;
 	getAttribute(type?: string, name?: string): Attribute | null;
 	getAttributes(type?: string, name?: string): Attribute[];
+	getBlob?(): Promise<FBlob>; // Available since Trilium v0.61.
 	getLabels(name: string): Attribute[];
 	getLabelValue(name: string): string | null;
-	getNoteComplement(): Promise<NoteComplement>;
+	getMetadata?(): Promise<FNoteMetadata>; // Available since Trilium v0.61.6.
+	getNoteComplement?(): Promise<FBlob | NoteComplement>; // Deprecated and returns FBlob since Trilium v0.61.
 	getRelationTargets(name?: string): Promise<NoteShort[]>;
 }
 
+// Available since Trilium v0.61.
+interface FBlob {
+	content?: string;
+	contentLength: number;
+	utcDateModified: string;
+}
+
+// Available since Trilium v0.61.6.
+interface FNoteMetadata {
+	utcDateCreated: string;
+	utcDateModified: string;
+}
+
+// Removed since Trilium v0.61.
 interface NoteComplement {
 	content?: string;
 	contentLength: number;

--- a/src/trilium.d.ts
+++ b/src/trilium.d.ts
@@ -26,7 +26,7 @@ interface NoteShort {
 
 // Available since Trilium v0.61.
 interface FBlob {
-	content?: string;
+	content: string | null;
 	contentLength: number;
 	utcDateModified: string;
 }


### PR DESCRIPTION
- Fix the `$dateCreated` and `$dateModified` properties displaying an empty value in Trilium v0.61+.
  - For Trilium v0.61.0 to v0.61.5, `$dateCreated` is not available and `$dateModified` will display the modification date of the note's content and not the note itself.

Fixes #41 