### PR TITLE
Fix scrolling issue with certain custom themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 - Unreleased
 
 - Fix scrolling issues (double scrollbar and scrolling down on load) that occur in Trilium v0.60+.
+- Fix a scrolling issue (view height slowly decreasing on load) that could occur with custom themes that change the parent scrollable container of notes to a different element.
 - Fix the `$dateCreated` and `$dateModified` properties displaying an empty value in Trilium v0.61+.
   - For Trilium v0.61.0 to v0.61.5, `$dateCreated` is not available and `$dateModified` will display the modification date of the note's content and not the note itself.
   - If you are using the v0.61 beta, upgrade to at least v0.61.6 for these dates to work as intended.

--- a/src/dom.test.ts
+++ b/src/dom.test.ts
@@ -7,6 +7,7 @@ import {
 	appendChildren,
 	fitToNoteDetailContainer,
 	fixIncludedNote,
+	getClosestScrollableElement,
 	renderError,
 	staggeredRender,
 } from "collection-views/dom";
@@ -72,6 +73,52 @@ describe("fitToNoteDetailContainer", () => {
 		fitToNoteDetailContainer($element);
 		observer.resize(mockApi.$component);
 		expect($element).toHaveStyle({ height: "" });
+	});
+
+	test("does nothing if no scrollable element found", () => {
+		mockApi.$component.style.overflowY = "hidden";
+		api.$container.append($element);
+		fitToNoteDetailContainer($element);
+		observer.resize(mockApi.$component);
+		expect($element).toHaveStyle({ height: "" });
+	});
+});
+
+describe("getClosestScrollableElement", () => {
+	let $element: HTMLElement;
+	let $parent: HTMLElement;
+	let $grandparent: HTMLElement;
+
+	beforeEach(() => {
+		$element = document.createElement("div");
+		$parent = document.createElement("div");
+		$parent.append($element);
+		$grandparent = document.createElement("div");
+		$grandparent.append($parent);
+	});
+
+	test("returns null if null", () => {
+		const $scroll = getClosestScrollableElement(null);
+		expect($scroll).toBeNull();
+	});
+
+	test("returns null if no scrollable element", () => {
+		$parent.style.overflowY = "hidden";
+		$grandparent.style.overflowY = "clip";
+		const $scroll = getClosestScrollableElement($element);
+		expect($scroll).toBeNull();
+	});
+
+	test("returns element itself if scrollable", () => {
+		$element.style.overflowY = "auto";
+		const $scroll = getClosestScrollableElement($element);
+		expect($scroll).toBe($element);
+	});
+
+	test("returns closest scrollable ancestor", () => {
+		$parent.style.overflowY = $grandparent.style.overflowY = "scroll";
+		const $scroll = getClosestScrollableElement($element);
+		expect($scroll).toBe($parent);
 	});
 });
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -23,14 +23,16 @@ export function renderError(message: string): void {
 }
 
 /**
- * Observes the container containing the current note's contents and resizes an
- * element to fit the container's height when the container is resized (keeping
- * the horizontal scrollbar at the bottom of the visible area).
+ * Observes the scrollable element containing the current note's contents and
+ * resizes an element to fit the container's height when the container is
+ * resized (keeping the horizontal scrollbar at the bottom of the visible area).
  */
 export function fitToNoteDetailContainer($element: HTMLElement): void {
-	const $container = api.$container[0].closest(".note-detail")?.parentElement;
+	const $container = getClosestScrollableElement(
+		api.$container[0].closest(".note-detail")
+	);
 	if (!$container) {
-		throw new Error("note container element not found");
+		return;
 	}
 
 	// The offset is the amount of borders, padding, and margin between the
@@ -77,6 +79,25 @@ export function fitToNoteDetailContainer($element: HTMLElement): void {
 		$element.style.height = height;
 		requestAnimationFrame(() => observer.observe($container));
 	}).observe($container);
+}
+
+/**
+ * Returns the closest element to the given element that can be vertically
+ * scrolled or null if no such element is found.
+ */
+export function getClosestScrollableElement(
+	$element: HTMLElement | null
+): HTMLElement | null {
+	while ($element) {
+		const style = getComputedStyle($element);
+		if (style.overflowY === "auto" || style.overflowY === "scroll") {
+			return $element;
+		}
+
+		$element = $element.parentElement;
+	}
+
+	return null;
 }
 
 /**

--- a/src/test/trilium.ts
+++ b/src/test/trilium.ts
@@ -14,6 +14,7 @@ export class MockApi {
 	constructor({ originEntity = null, notes = [] }: MockApiProps = {}) {
 		this.$component = document.createElement("div");
 		this.$component.className = "component";
+		this.$component.style.overflowY = "auto";
 		this.$component.style.scrollBehavior = "smooth";
 		this.$component.innerHTML = `
 			<div class="note-detail component">


### PR DESCRIPTION
- Fix a scrolling issue (view height slowly decreasing on load) that could occur with custom themes that change the parent scrollable container of notes to a different element.